### PR TITLE
Remove context menu on plot control table

### DIFF
--- a/pybleau/app/ui/dataframe_plot_manager_view.py
+++ b/pybleau/app/ui/dataframe_plot_manager_view.py
@@ -149,10 +149,11 @@ class DataFramePlotManagerView(ModelView):
             auto_size=True,
             sortable=True,
             h_size_policy="expanding",
-            deletable=True,
             editable=True,
             edit_on_first_click=False,
-            reorderable=True,
+            reorderable=False,
+            row_factory=None,
+            deletable=False
         )
         return plot_list_editor
 


### PR DESCRIPTION
Now that there is a `Move/Delete` column to control the location of the plots in the plot canvas, this turns off both deletable and reorderable on plot control table so users can't modify the list that way and there is only 1 way to do something. 2 reasons:
- The context menu could put users in a broken state due to a complex interaction between the MultiCanvas object and the list of descriptors.
- Additionally, some bug in TraitsUI's `SplitEditorAreaPane` would sometimes highjack the context menu events.
- Removing these operations also simplifies the view, because it hides the additional index which was redundant with our own ID column.