### PR TITLE
Enh: control if string axis labels can be decimated

### DIFF
--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -76,6 +76,10 @@ class BasePlotStyle(HasStrictTraits):
     #: Angle to rotate the Y axis labels (string x values only)
     y_axis_label_rotation = Int
 
+    #: Whether to force display of all values along X axis or allow decimation
+    # (ONLY USED with string labels)
+    show_all_x_ticks = Bool
+
     #: Low value of the x-axis range
     x_axis_range_low = Float(-1)
 
@@ -133,7 +137,7 @@ class BasePlotStyle(HasStrictTraits):
                 "x_axis_label_rotation", "y_axis_label_rotation",
                 "title_font_name", "index_scale", "value_scale",
                 "x_axis_range_low", "x_axis_range_high", "y_axis_range_low",
-                "y_axis_range_high"]
+                "y_axis_range_high", "show_all_x_ticks"]
 
     def _get_general_view_elements(self):
         elemens = (
@@ -280,8 +284,16 @@ class BarPlotStyle(BasePlotStyle):
     #: Whether to display error bars when multiple values contribute to a bar
     show_error_bars = Bool
 
+    #: Whether to force display of all values along X axis or allow decimation
+    # (ONLY USED with string labels)
+    show_all_x_ticks = Bool(True)
+
     def traits_view(self):
         allow_errors = "data_duplicate != '{}'".format(IGNORE_DATA_DUPLICATES)
+
+        # FIXME: find a way to insert that extra entry into the Axis group:
+        general_view_elements = list(self.general_view_elements) + \
+            [Item('show_all_x_ticks')]
 
         view = self.view_klass(
             VGroup(
@@ -298,9 +310,9 @@ class BarPlotStyle(BasePlotStyle):
                     ),
                     show_border=True, label=SPECIFIC_CONFIG_CONTROL_LABEL
                 ),
-                *self.general_view_elements
+                *general_view_elements
             ),
-            **self.view_kw
+            **self.view_kw,
         )
         return view
 

--- a/scripts/explore_dataframe_with_plots.py
+++ b/scripts/explore_dataframe_with_plots.py
@@ -13,9 +13,10 @@ from pybleau.app.plotting.api import BarPlotConfigurator, \
 
 initialize_logging(logging_level="DEBUG")
 
-TEST_DF = DataFrame({"Col_1": [1, 2, 3, 4],
-                     "Col_2": np.array([1, 2, 3, 4])[::-1],
-                     "Col_3": list("abab"),
+TEST_DF = DataFrame({"Col_1": [1, 2, 3, 4, 5, 6, 7, 8],
+                     "Col_2": np.array([1, 2, 3, 4, 5, 6, 7, 8])[::-1],
+                     "Col_3": ["aa_aaa", "bb_bbb", "aa_aaa", "cc_ccc",
+                               "ee_eee", "dd_ddd", "ff_fff", "gg_ggg"],
 })
 
 config = HistogramPlotConfigurator(data_source=TEST_DF)
@@ -55,10 +56,16 @@ cust_plot1.title = "Blah"
 cust_plot1.x_axis.title = "x"
 cust_plot1.y_axis.title = "y"
 
+config6 = BarPlotConfigurator(data_source=TEST_DF)
+config6.x_col_name = "Col_3"
+config6.y_col_name = "Col_1"
+desc6 = PlotDescriptor(x_col_name="Col_3", y_col_name="Col_1",
+                       plot_config=config6, plot_title="Plot 6")
+
 analyzer = DataFrameAnalyzer(source_df=TEST_DF)
 
 plot_manager = DataFramePlotManager(
-    contained_plots=[desc, desc2, desc3, desc4, desc5, cust_plot1],
+    contained_plots=[desc, desc2, desc3, desc4, desc5, cust_plot1, desc6],
     data_source=TEST_DF, source_analyzer=analyzer
 )
 


### PR DESCRIPTION
When building bar plots with a string index, we may not want to apply the normal chaco tick decimation algorithm. Add a check box in the styling UI to force the display of all values.

![Screen Shot 2020-01-20 at 4 27 18 PM](https://user-images.githubusercontent.com/593945/72761546-f5554100-3ba1-11ea-9061-20655fe2997d.png)

