### PR TITLE
Fix Python 2 syntax error

### DIFF
--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -312,7 +312,7 @@ class BarPlotStyle(BasePlotStyle):
                 ),
                 *self.general_view_elements
             ),
-            **self.view_kw,
+            **self.view_kw
         )
         return view
 


### PR DESCRIPTION
#9 introduced a syntax error on Python2 only. This fixes it so both versions of Python are still supported.