### PR TITLE
Move architecture from Plot to OverlayPlotContainer

### DIFF
--- a/pybleau/app/io/deserializer.py
+++ b/pybleau/app/io/deserializer.py
@@ -116,6 +116,13 @@ class scatterRendererStyleDeSerializer(dataElementDeSerializer):
         return ScatterRendererStyle
 
 
+class cmapScatterRendererStyleDeSerializer(dataElementDeSerializer):
+    def _klass_default(self):
+        from pybleau.app.plotting.renderer_style import \
+            CmapScatterRendererStyle
+        return CmapScatterRendererStyle
+
+
 class barRendererStyleDeSerializer(dataElementDeSerializer):
     def _klass_default(self):
         from pybleau.app.plotting.renderer_style import BarRendererStyle

--- a/pybleau/app/io/deserializer.py
+++ b/pybleau/app/io/deserializer.py
@@ -30,7 +30,7 @@ class dataFramePlotManagerDeSerializer(dataElementDeSerializer):
 
 class plotDescriptorDeSerializer(dataElementDeSerializer):
 
-    protocol_version = 1
+    protocol_version = 2
 
     def _klass_default(self):
         from pybleau.app.model.plot_descriptor import PlotDescriptor

--- a/pybleau/app/io/deserializer.py
+++ b/pybleau/app/io/deserializer.py
@@ -150,3 +150,10 @@ class contourStyleDeSerializer(dataElementDeSerializer):
     def _klass_default(self):
         from pybleau.app.plotting.contour_style import ContourStyle
         return ContourStyle
+
+
+class plotContainerStyleDeSerializer(dataElementDeSerializer):
+    def _klass_default(self):
+        from pybleau.app.plotting.plot_container_style import \
+            PlotContainerStyle
+        return PlotContainerStyle

--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -110,24 +110,24 @@ class HeatmapPlotConfigurator_Serializer(BaseSinglePlotConfigurator_Serializer):
     pass
 
 
-class BasePlotStyle_Serializer(Serializer):
+class BaseXYPlotStyle_Serializer(Serializer):
     def attr_names_to_serialize(self, obj):
         return ['title_style', 'renderer_styles', 'x_axis_style',
-                'y_axis_style']
+                'y_axis_style', "container_style"]  #, "second_y_axis_style"
 
 
-class BaseColorXYPlotStyle_Serializer(BasePlotStyle_Serializer):
+class BaseColorXYPlotStyle_Serializer(BaseXYPlotStyle_Serializer):
     def attr_names_to_serialize(self, obj):
         attrs = super(BaseColorXYPlotStyle_Serializer, self).attr_names_to_serialize(obj)  # noqa
         return attrs + ['color_palette', 'color_axis_title_style',
                         'colorbar_low', 'colorbar_high', 'colorize_by_float']
 
 
-class SingleScatterPlotStyle_Serializer(BasePlotStyle_Serializer):
+class SingleScatterPlotStyle_Serializer(BaseXYPlotStyle_Serializer):
     pass
 
 
-class SingleLinePlotStyle_Serializer(BasePlotStyle_Serializer):
+class SingleLinePlotStyle_Serializer(BaseXYPlotStyle_Serializer):
     pass
 
 
@@ -137,7 +137,7 @@ class BarPlotStyle_Serializer(BaseColorXYPlotStyle_Serializer):
         return attrs + ["bar_style", "data_duplicate", "show_error_bars"]
 
 
-class HistogramPlotStyle_Serializer(BasePlotStyle_Serializer):
+class HistogramPlotStyle_Serializer(BaseXYPlotStyle_Serializer):
     def attr_names_to_serialize(self, obj):
         attrs = super(HistogramPlotStyle_Serializer, self).attr_names_to_serialize(obj)  # noqa
         return attrs + ["num_bins", "bin_limits", "bar_width_factor"]
@@ -205,3 +205,9 @@ class ContourStyle_Serializer(Serializer):
     def attr_names_to_serialize(self, obj):
         return ["add_contours", "contour_levels", "contour_styles",
                 "contour_alpha", "contour_widths"]
+
+
+class PlotContainerStyle_Serializer(Serializer):
+    def attr_names_to_serialize(self, obj):
+        return ["padding_left", "padding_right", "padding_top",
+                "padding_bottom", "border_visible", "include_colorbar"]

--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -60,7 +60,7 @@ class PlotDescriptor_Serializer(DataElement_Serializer):
         # PlotConfigurator it contains since the plots are rebuilt from the
         # config
         return ['visible', "data_filter", "plot_config", "frozen",
-                "container_idx", "id", "ndim", "plot_type"]
+                "container_idx", "id", "plot_type"]
 
 
 class BaseSinglePlotConfigurator_Serializer(DataElement_Serializer):

--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -113,7 +113,7 @@ class HeatmapPlotConfigurator_Serializer(BaseSinglePlotConfigurator_Serializer):
 class BaseXYPlotStyle_Serializer(Serializer):
     def attr_names_to_serialize(self, obj):
         return ['title_style', 'renderer_styles', 'x_axis_style',
-                'y_axis_style', "container_style"]  #, "second_y_axis_style"
+                'y_axis_style', "container_style", "second_y_axis_style"]
 
 
 class BaseColorXYPlotStyle_Serializer(BaseXYPlotStyle_Serializer):

--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -44,7 +44,7 @@ class DataFramePlotManager_Serializer(DataElement_Serializer):
 
 class PlotDescriptor_Serializer(DataElement_Serializer):
 
-    protocol_version = 1
+    protocol_version = 2
 
     def get_instance_data(self, obj):
         data = super(PlotDescriptor_Serializer, self).get_instance_data(obj)

--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -210,4 +210,5 @@ class ContourStyle_Serializer(Serializer):
 class PlotContainerStyle_Serializer(Serializer):
     def attr_names_to_serialize(self, obj):
         return ["padding_left", "padding_right", "padding_top",
-                "padding_bottom", "border_visible", "include_colorbar"]
+                "padding_bottom", "border_visible", "include_colorbar",
+                "bgcolor"]

--- a/pybleau/app/io/tests/test_plot_styles_roundtrip.py
+++ b/pybleau/app/io/tests/test_plot_styles_roundtrip.py
@@ -1,6 +1,5 @@
 
 from unittest import TestCase
-from traits.testing.unittest_tools import UnittestTools
 
 from app_common.apptools.io.assertion_utils import assert_roundtrip_identical
 
@@ -16,7 +15,7 @@ from pybleau.app.plotting.heatmap_plot_style import HeatmapPlotStyle
 from pybleau.app.plotting.bar_plot_style import BarPlotStyle
 
 
-class BaseSerialDataTest(UnittestTools):
+class BaseSerialDataTest(object):
 
     def setUp(self):
         title_style = TitleStyle(font_size=12, font_name="roman")

--- a/pybleau/app/io/tests/test_plotting_roundtrip.py
+++ b/pybleau/app/io/tests/test_plotting_roundtrip.py
@@ -26,66 +26,6 @@ TEST_DF2 = pd.DataFrame({"Col_1": [1, 2, 1, 2],
                          "Col_3": np.random.randn(4)})
 
 
-config = HistogramPlotConfigurator(data_source=TEST_DF)
-config.x_col_name = "Col_4"
-desc = PlotDescriptor(x_col_name="Col_4", plot_config=config,
-                      plot_title="Plot 1")
-
-config2 = BarPlotConfigurator(data_source=TEST_DF)
-config2.x_col_name = "Col_1"
-config2.y_col_name = "Col_2"
-desc2 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
-                       plot_config=config2, plot_title="Plot 2")
-
-config3 = ScatterPlotConfigurator(data_source=TEST_DF)
-config3.x_col_name = "Col_1"
-config3.y_col_name = "Col_2"
-desc3 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
-                       plot_config=config3, plot_title="Plot 3")
-
-config4 = ScatterPlotConfigurator(data_source=TEST_DF)
-config4.x_col_name = "Col_1"
-config4.y_col_name = "Col_2"
-config4.z_col_name = "Col_3"
-desc4 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
-                       z_col_name="Col_3",
-                       plot_config=config4, plot_title="Plot 4")
-
-config5 = LinePlotConfigurator(data_source=TEST_DF)
-config5.x_col_name = "Col_1"
-config5.y_col_name = "Col_2"
-desc5 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
-                       plot_config=config5, plot_title="Plot 5")
-
-config6 = BarPlotConfigurator(data_source=TEST_DF)
-config6.x_col_name = "Col_3"
-config6.y_col_name = "Col_1"
-desc6 = PlotDescriptor(x_col_name="Col_3", y_col_name="Col_1",
-                       plot_config=config6, plot_title="Plot 6")
-
-analyzer = DataFrameAnalyzer(source_df=TEST_DF)
-
-plot_manager = DataFramePlotManager(
-    contained_plots=[desc, desc2, desc3, desc4, desc5, desc6],
-    data_source=TEST_DF, source_analyzer=analyzer
-)
-
-config7 = HeatmapPlotConfigurator(data_source=TEST_DF2)
-config7.x_col_name = "Col_1"
-config7.y_col_name = "Col_2"
-config7.z_col_name = "Col_3"
-desc7 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
-                       z_col_name="Col_3",
-                       plot_config=config7, plot_title="Plot 6")
-
-analyzer2 = DataFrameAnalyzer(source_df=TEST_DF2)
-
-plot_manager2 = DataFramePlotManager(
-    contained_plots=[desc7],
-    data_source=TEST_DF2, source_analyzer=analyzer2
-)
-
-
 class TestRoundTripDataFramePlotManager(TestCase):
     def setUp(self):
         self.ignore = ("source_analyzer", "data_source", "canvas_manager",
@@ -93,10 +33,89 @@ class TestRoundTripDataFramePlotManager(TestCase):
                        "inspectors")
 
     def test_round_trip_df_plotter_basic_types(self):
+        config = HistogramPlotConfigurator(data_source=TEST_DF)
+        config.x_col_name = "Col_4"
+        desc = PlotDescriptor(x_col_name="Col_4", plot_config=config,
+                              plot_title="Plot 1")
+
+        config2 = BarPlotConfigurator(data_source=TEST_DF)
+        config2.x_col_name = "Col_1"
+        config2.y_col_name = "Col_2"
+        desc2 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
+                               plot_config=config2, plot_title="Plot 2")
+
+        config3 = ScatterPlotConfigurator(data_source=TEST_DF)
+        config3.x_col_name = "Col_1"
+        config3.y_col_name = "Col_2"
+        desc3 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
+                               plot_config=config3, plot_title="Plot 3")
+
+        config4 = ScatterPlotConfigurator(data_source=TEST_DF)
+        config4.x_col_name = "Col_1"
+        config4.y_col_name = "Col_2"
+        config4.z_col_name = "Col_3"
+        desc4 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
+                               z_col_name="Col_3",
+                               plot_config=config4, plot_title="Plot 4")
+
+        config5 = LinePlotConfigurator(data_source=TEST_DF)
+        config5.x_col_name = "Col_1"
+        config5.y_col_name = "Col_2"
+        desc5 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
+                               plot_config=config5, plot_title="Plot 5")
+
+        config6 = BarPlotConfigurator(data_source=TEST_DF)
+        config6.x_col_name = "Col_3"
+        config6.y_col_name = "Col_1"
+        desc6 = PlotDescriptor(x_col_name="Col_3", y_col_name="Col_1",
+                               plot_config=config6, plot_title="Plot 6")
+
+        analyzer = DataFrameAnalyzer(source_df=TEST_DF)
+
+        plot_manager = DataFramePlotManager(
+            contained_plots=[desc, desc2, desc3, desc4, desc5, desc6],
+            data_source=TEST_DF, source_analyzer=analyzer
+        )
+
+        self.assert_roundtrip_identical(plot_manager, ignore=self.ignore)
+
+    def test_round_trip_df_plotter_cmap_scatter_type(self):
+        config = ScatterPlotConfigurator(data_source=TEST_DF)
+        config.x_col_name = "Col_1"
+        config.y_col_name = "Col_2"
+        config.z_col_name = "Col_4"
+        desc = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
+                              z_col_name="Col_4",
+                              plot_config=config, plot_title="Plot 6")
+
+        analyzer = DataFrameAnalyzer(source_df=TEST_DF)
+
+        plot_manager = DataFramePlotManager(
+            contained_plots=[desc],
+            data_source=TEST_DF, source_analyzer=analyzer
+        )
+
         self.assert_roundtrip_identical(plot_manager, ignore=self.ignore)
 
     def test_round_trip_df_plotter_heatmap_types(self):
+        config7 = HeatmapPlotConfigurator(data_source=TEST_DF2)
+        config7.x_col_name = "Col_1"
+        config7.y_col_name = "Col_2"
+        config7.z_col_name = "Col_3"
+        desc7 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
+                               z_col_name="Col_3",
+                               plot_config=config7, plot_title="Plot 6")
+
+        analyzer2 = DataFrameAnalyzer(source_df=TEST_DF2)
+
+        plot_manager2 = DataFramePlotManager(
+            contained_plots=[desc7],
+            data_source=TEST_DF2, source_analyzer=analyzer2
+        )
+
         self.assert_roundtrip_identical(plot_manager2, ignore=self.ignore)
+
+    # Support methods ---------------------------------------------------------
 
     def assert_roundtrip_identical(self, obj, **kwargs):
         assert_roundtrip_identical(obj, serial_func=serialize,

--- a/pybleau/app/model/dataframe_plot_manager.py
+++ b/pybleau/app/model/dataframe_plot_manager.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import logging
 from uuid import UUID
-import numpy as np
 
 from traits.api import Dict, Enum, Instance, Int, List, on_trait_change, \
     Property, Set, Str
@@ -17,9 +16,7 @@ from .plot_descriptor import CONTAINER_IDX_REMOVAL, CUSTOM_PLOT_TYPE, \
     PlotDescriptor
 from ..plotting.plot_config import BaseSinglePlotConfigurator
 from ..plotting.plot_factories import DEFAULT_FACTORIES, \
-    DISCONNECTED_SELECTION_COLOR, HistogramPlotFactory, ScatterPlotFactory, \
-    SELECTION_COLOR, SELECTION_METADATA_NAME
-from ..plotting.base_factories import DEFAULT_RENDERER_NAME
+    DISCONNECTED_SELECTION_COLOR, SELECTION_COLOR, SELECTION_METADATA_NAME
 from ..plotting.api import HEATMAP_PLOT_TYPE
 from ..model.multi_canvas_manager import MultiCanvasManager
 

--- a/pybleau/app/model/dataframe_plot_manager.py
+++ b/pybleau/app/model/dataframe_plot_manager.py
@@ -231,7 +231,7 @@ class DataFramePlotManager(DataElement):
                     self._add_raw_plot(desc, position=i, list_op="replace")
             except Exception as e:
                 tb = extract_traceback()
-                msg = "Failed to recreate the plot number {} ({} named {} of " \
+                msg = "Failed to recreate the plot number {} ({} named {} of "\
                       "'{}' vs '{}', z_col '{}').\nError was {}. Traceback " \
                       "was:\n{}"
                 msg = msg.format(i, desc.plot_type, desc.plot_title,

--- a/pybleau/app/model/dataframe_plot_manager.py
+++ b/pybleau/app/model/dataframe_plot_manager.py
@@ -231,10 +231,12 @@ class DataFramePlotManager(DataElement):
                     self._add_raw_plot(desc, position=i, list_op="replace")
             except Exception as e:
                 tb = extract_traceback()
-                msg = "Failed to recreate the plot number {} ({} of '{}' vs " \
-                      "'{}', z_col '{}').\nError was {}. Traceback was:\n{}"
-                msg = msg.format(i, desc.plot_type, desc.x_col_name,
-                                 desc.y_col_name, desc.z_col_name, e, tb)
+                msg = "Failed to recreate the plot number {} ({} named {} of " \
+                      "'{}' vs '{}', z_col '{}').\nError was {}. Traceback " \
+                      "was:\n{}"
+                msg = msg.format(i, desc.plot_type, desc.plot_title,
+                                 desc.x_col_name, desc.y_col_name,
+                                 desc.z_col_name, e, tb)
                 logger.error(msg)
                 self.failed_plots.append(desc)
 

--- a/pybleau/app/model/plot_descriptor.py
+++ b/pybleau/app/model/plot_descriptor.py
@@ -6,6 +6,7 @@ from traits.api import Any, Bool, Button, Enum, Event, HasStrictTraits, \
 from pybleau.app.plotting.plot_config import BasePlotConfigurator
 from pybleau.app.plotting.base_factories import BasePlotFactory
 from ..plotting.api import PLOT_TYPES
+from ..utils.string_definitions import CMAP_SCATTER_PLOT_TYPE
 
 CONTAINER_IDX_REMOVAL = "delete"
 
@@ -39,7 +40,7 @@ class PlotDescriptor(HasStrictTraits):
     plot_factory = Instance(BasePlotFactory)
 
     #: Type of plot
-    plot_type = Enum(PLOT_TYPES + [CUSTOM_PLOT_TYPE])
+    plot_type = Enum(PLOT_TYPES + [CMAP_SCATTER_PLOT_TYPE, CUSTOM_PLOT_TYPE])
 
     #: Title of the plot
     plot_title = Str

--- a/pybleau/app/model/plot_descriptor.py
+++ b/pybleau/app/model/plot_descriptor.py
@@ -26,9 +26,6 @@ class PlotDescriptor(HasStrictTraits):
     # PlotManager.
     container_idx = Any
 
-    #: Number of dimensions, that's number of columns involved to make the plot
-    ndim = Int
-
     #: Filter expression applied to the source_data to build this plot
     data_filter = Str
 

--- a/pybleau/app/model/plot_descriptor.py
+++ b/pybleau/app/model/plot_descriptor.py
@@ -1,7 +1,7 @@
 
 from chaco.base_plot_container import BasePlotContainer
 from traits.api import Any, Bool, Button, Enum, Event, HasStrictTraits, \
-    Instance, Int, Str
+    Instance, Str
 
 from pybleau.app.plotting.plot_config import BasePlotConfigurator
 from pybleau.app.plotting.base_factories import BasePlotFactory

--- a/pybleau/app/model/plot_descriptor.py
+++ b/pybleau/app/model/plot_descriptor.py
@@ -77,6 +77,10 @@ class PlotDescriptor(HasStrictTraits):
     #: Event triggered if the plot's styling is changed and plot needs updating
     style_edited = Event
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(plot_config=config)
+
     # Traits listeners --------------------------------------------------------
 
     def _edit_plot_style_fired(self):

--- a/pybleau/app/plotting/axis_style.py
+++ b/pybleau/app/plotting/axis_style.py
@@ -6,6 +6,10 @@ from traitsui.api import HGroup, InstanceEditor, Item, RangeEditor, VGroup, \
 
 from .title_style import TitleStyle
 
+LINEAR_AXIS_STYLE = "linear"
+
+LOG_AXIS_STYLE = "log"
+
 
 class AxisStyle(HasStrictTraits):
 
@@ -38,7 +42,7 @@ class AxisStyle(HasStrictTraits):
     reset_range = Button("Reset")
 
     #: Selector for the scaling of the axis: log or linear?
-    scaling = Enum("linear", "log")
+    scaling = Enum(LINEAR_AXIS_STYLE, LOG_AXIS_STYLE)
 
     #: View klass. Override to customize the views, for example their icon
     view_klass = Any(default_value=View)

--- a/pybleau/app/plotting/bar_factory.py
+++ b/pybleau/app/plotting/bar_factory.py
@@ -7,6 +7,9 @@ import pandas as pd
 import logging
 
 from traits.api import Any, Constant
+
+from app_common.chaco.plot_factory import create_line_plot
+
 from .plot_config import BAR_PLOT_TYPE
 from .bar_plot_style import IGNORE_DATA_DUPLICATES
 from .base_factories import StdXYPlotFactory
@@ -93,12 +96,14 @@ class BarPlotFactory(StdXYPlotFactory):
             x = bar_positions[i]
             x_data_name = ERROR_BAR_DATA_KEY_PREFIX + "{}_x".format(i)
             y_data_name = ERROR_BAR_DATA_KEY_PREFIX + "{}_y".format(i)
-            self.plot_data.set_data(x_data_name, [x, x])
-            self.plot_data.set_data(y_data_name,
-                                    [y_val+stddev/2., y_val-stddev/2.])
+            self.plot_data.set_data(x_data_name, np.array([x, x]))
+            y_array = np.array([y_val+stddev/2., y_val-stddev/2.])
+            self.plot_data.set_data(y_data_name, y_array)
             error_bar_renderer_name = "plot{}".format(i+1)
-            plot.plot((x_data_name, y_data_name), type="line",
-                      color=ERROR_BAR_COLOR, name=error_bar_renderer_name)
+            error_renderer = create_line_plot(data=(np.array([x, x]), y_array),
+                                              color=ERROR_BAR_COLOR)
+            plot.add(error_renderer)
+            self.renderers[error_bar_renderer_name] = error_renderer
 
     def _draw_error_bars_multi_renderer(self, plot):
         """ Add data and renderers for drawing error bars around bar heights.
@@ -118,12 +123,15 @@ class BarPlotFactory(StdXYPlotFactory):
                 y_data_name = ERROR_BAR_DATA_KEY_PREFIX + "{}_y".format(
                     renderer_num
                 )
-                self.plot_data.set_data(x_data_name, [x, x])
-                self.plot_data.set_data(y_data_name,
-                                        [y_val+stddev/2., y_val-stddev/2.])
+                x_array = np.array([x, x])
+                self.plot_data.set_data(x_data_name, x_array)
+                y_array = np.array([y_val+stddev/2., y_val-stddev/2.])
+                self.plot_data.set_data(y_data_name, y_array)
                 name = "plot{}".format(renderer_num)
-                plot.plot((x_data_name, y_data_name), type="line",
-                          color=ERROR_BAR_COLOR, name=name)
+                error_renderer = create_line_plot(data=(x_array, y_array),
+                                                  color=ERROR_BAR_COLOR)
+                plot.add(error_renderer)
+                self.renderers[name] = error_renderer
 
     def _compute_bar_width(self):
         """ Compute the width of each bar.

--- a/pybleau/app/plotting/bar_factory.py
+++ b/pybleau/app/plotting/bar_factory.py
@@ -26,9 +26,6 @@ logger = logging.getLogger(__name__)
 class BarPlotFactory(StdXYPlotFactory):
     """ Factory to build a bar plot.
     """
-    #: Plot type as used by Plot.plot
-    plot_type_name = Constant("bar")
-
     #: Plot type as selected by user
     plot_type = Constant(BAR_PLOT_TYPE)
 
@@ -212,11 +209,6 @@ class BarPlotFactory(StdXYPlotFactory):
         return super(BarPlotFactory, self)._plot_data_multi_renderer(
             x_arr=x_arr, y_arr=y_arr, z_arr=z_arr, **adtl_arrays
         )
-
-    # Trait initialization methods --------------------------------------------
-
-    def _plot_tools_default(self):
-        return {"zoom", "pan", "legend"}
 
 
 def _split_avg_for_bar_heights(x_arr, y_arr, force_index=None):

--- a/pybleau/app/plotting/base_factories.py
+++ b/pybleau/app/plotting/base_factories.py
@@ -366,12 +366,14 @@ class StdXYPlotFactory(BasePlotFactory):
                     z_axis_title=self.z_axis_title, ndim=self.ndim)
 
         if self.plot_style.container_style.include_colorbar:
+            self.generate_colorbar(desc)
             self.add_colorbar(desc)
 
         return desc
 
     def add_colorbar(self, desc):
-        # FIXME: what plot factories need this? Reconcile with ScatterFactory.
+        """ A colorbar was created. Embed it together with the plot.
+        """
         plot = desc["plot"]
         # Make more room for labels
         plot.padding_right = 5

--- a/pybleau/app/plotting/base_factories.py
+++ b/pybleau/app/plotting/base_factories.py
@@ -137,12 +137,16 @@ class BasePlotFactory(HasStrictTraits):
             else:
                 tick_generator = DefaultTickGenerator()
 
-            bottom_axis = LabelAxis(plot, orientation="bottom",
+            first_renderer = plot.components[0]
+            bottom_axis = LabelAxis(first_renderer, orientation="bottom",
                                     labels=[str(x) for x in x_labels],
                                     positions=np.arange(len(x_labels)),
                                     label_rotation=label_rotation,
                                     tick_generator=tick_generator)
             plot.x_axis = bottom_axis
+            # Replace in the underlay list too:
+            plot.underlays.pop(0)
+            plot.underlays.insert(0, bottom_axis)
 
         plot.x_axis.title = self.x_axis_title
         font_size = self.plot_style.x_axis_style.title_style.font_size
@@ -439,9 +443,12 @@ class StdXYPlotFactory(BasePlotFactory):
             #     x_mapper_klass = LinearMapper
 
             left_axis, bottom_axis = add_default_axes(renderer)
-            # Add to plot (displays) and keep a handle on the axis objects:
+            # Keep a handle on the axis objects and move all axis in plot's
+            # underlays:
             plot.x_axis = bottom_axis
             plot.y_axis = left_axis
+            renderer.underlays = []
+            plot.underlays = [bottom_axis, left_axis]
         else:
             if style.orientation == STYLE_R_ORIENT and not \
                     hasattr(plot, "second_y_axis"):
@@ -452,9 +459,9 @@ class StdXYPlotFactory(BasePlotFactory):
 
                 second_y_axis = PlotAxis(component=renderer,
                                          orientation="right")
-                renderer.underlays.append(second_y_axis)
-                # Keep a handle on the axis object:
+                # Keep a handle on the axis object and display
                 plot.second_y_axis = second_y_axis
+                plot.underlays.append(second_y_axis)
 
         return renderer
 

--- a/pybleau/app/plotting/base_factories.py
+++ b/pybleau/app/plotting/base_factories.py
@@ -365,22 +365,20 @@ class StdXYPlotFactory(BasePlotFactory):
                     y_axis_title=self.y_axis_title, z_col_name=self.z_col_name,
                     z_axis_title=self.z_axis_title, ndim=self.ndim)
 
-        self.add_colorbar(desc)
+        if self.plot_style.container_style.include_colorbar:
+            self.add_colorbar(desc)
 
         return desc
 
     def add_colorbar(self, desc):
         # FIXME: what plot factories need this? Reconcile with ScatterFactory.
-        if not self.plot_style.container_style.include_colorbar:
-            return
-
         plot = desc["plot"]
         # Make more room for labels
         plot.padding_right = 5
         plot.padding_top = 25
 
         container = HPlotContainer(
-            self.plot_style.container_style.to_traits()
+            **self.plot_style.container_style.to_traits()
         )
         container.add(plot, self.colorbar)
         container.padding_right = sum([comp.padding_right

--- a/pybleau/app/plotting/base_factories.py
+++ b/pybleau/app/plotting/base_factories.py
@@ -93,8 +93,8 @@ class BasePlotFactory(HasStrictTraits):
     #: Label to display along the z-axis
     z_axis_title = Str
 
-    #: list of tools requested on the plot
-    plot_tools = Set({"zoom", "pan"})
+    #: list of tools requested on the plot/renderers
+    plot_tools = Set
 
     #: Inspector tool and overlay to hover over or select scatter data points
     inspector = Any
@@ -358,7 +358,7 @@ class StdXYPlotFactory(BasePlotFactory):
         return desc
 
     def add_colorbar(self, desc):
-        """ A colorbar was created. Embed it together with the plot.
+        """ Need a colorbar. Embed it together with plot & replace in desc.
         """
         plot = desc["plot"]
         # Make more room for labels
@@ -518,7 +518,7 @@ class StdXYPlotFactory(BasePlotFactory):
                       " incomplete because x was set as removed and not y or" \
                       " vice versa. Removed keys: {}. Please report this " \
                       "issue.".format(desc["name"], removed)
-                logger.error(msg)
+                logger.exception(msg)
                 raise ValueError(msg)
             else:
                 x = self.plot_data.get_data(desc["x"])

--- a/pybleau/app/plotting/base_factories.py
+++ b/pybleau/app/plotting/base_factories.py
@@ -19,8 +19,7 @@ import numpy as np
 import pandas as pd
 import logging
 
-from traits.api import Any, Dict, HasStrictTraits, Instance, Int, List, Set, \
-    Str
+from traits.api import Any, Dict, HasStrictTraits, Instance, List, Set, Str
 from chaco.api import ArrayPlotData, ColorBar, HPlotContainer, LabelAxis, \
     OverlayPlotContainer, PlotAxis, PlotLabel  # LinearMapper, LogMapper,
 from chaco.plot_factory import add_default_axes

--- a/pybleau/app/plotting/base_factories.py
+++ b/pybleau/app/plotting/base_factories.py
@@ -198,9 +198,6 @@ class StdXYPlotFactory(BasePlotFactory):
     #: Generated chaco plot containing all requested renderers
     plot = Instance(OverlayPlotContainer)
 
-    #: Number of DF columns involved in making the plot
-    ndim = Int
-
     #: List of plot_data keys to plot in pairs, one pair per renderer
     renderer_desc = List(Dict)
 
@@ -232,11 +229,6 @@ class StdXYPlotFactory(BasePlotFactory):
         if self.plot_data is None:
             self.initialize_plot_data(x_arr=x_arr, y_arr=y_arr, z_arr=z_arr,
                                       **hover_data)
-
-        if self.z_col_name:
-            self.ndim = 3
-        else:
-            self.ndim = 2
 
         self.adjust_plot_style(x_arr=x_arr, y_arr=y_arr, z_arr=z_arr)
 
@@ -334,13 +326,7 @@ class StdXYPlotFactory(BasePlotFactory):
         return col_name + hue_name
 
     def generate_plot(self):
-        """ Generate and return a line plot & a dict describing its properties.
-
-        Returns
-        -------
-        dict
-            Dictionary containing the generated plot and all the information
-            about it to create a PlotDescriptor.
+        """ Generate and return a dict containing a plot and its properties.
         """
         plot = self.plot = OverlayPlotContainer(
             **self.plot_style.container_style.to_traits()
@@ -363,7 +349,7 @@ class StdXYPlotFactory(BasePlotFactory):
                     plot_title=self.plot_title, x_col_name=self.x_col_name,
                     y_col_name=self.y_col_name, x_axis_title=self.x_axis_title,
                     y_axis_title=self.y_axis_title, z_col_name=self.z_col_name,
-                    z_axis_title=self.z_axis_title, ndim=self.ndim)
+                    z_axis_title=self.z_axis_title)
 
         if self.plot_style.container_style.include_colorbar:
             self.generate_colorbar(desc)
@@ -443,8 +429,7 @@ class StdXYPlotFactory(BasePlotFactory):
             #     x_mapper_klass = LinearMapper
 
             left_axis, bottom_axis = add_default_axes(renderer)
-            # Keep a handle on the axis objects and move all axis in plot's
-            # underlays:
+            # Emulate chaco.Plot interface:
             plot.x_axis = bottom_axis
             plot.y_axis = left_axis
             renderer.underlays = []
@@ -574,3 +559,8 @@ class StdXYPlotFactory(BasePlotFactory):
 
             if self.legend:
                 self.legend.plots[rend_desc["name"]] = renderer
+
+    # Traits initialization methods -------------------------------------------
+
+    def _plot_tools_default(self):
+        return {"zoom", "pan", "legend"}

--- a/pybleau/app/plotting/heatmap_factory.py
+++ b/pybleau/app/plotting/heatmap_factory.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class HeatmapPlotFactory(StdXYPlotFactory):
-    """ Factory to build a heatmap plot.
+    """ Factory to build a plot with a heatmap renderer.
     """
     plot_type = Constant(HEATMAP_PLOT_TYPE)
 
@@ -75,15 +75,15 @@ class HeatmapPlotFactory(StdXYPlotFactory):
         plot.underlays.append(plot.x_axis)
         plot.underlays.append(plot.y_axis)
 
-        if self.plot_style.container_style.include_colorbar:
-            self.generate_colorbar(renderer, plot)
-
         if self.plot_style.contour_style.add_contours:
             self.generate_contours(plot)
 
-    def generate_colorbar(self, renderer, plot):
+    def generate_colorbar(self, desc):
         """ Generate the colorbar to be displayed along side the main plot.
         """
+        plot = desc["plot"]
+        renderer = plot.components[0]
+
         colormap = renderer.color_mapper
         # Constant mapper for the color bar so that the colors stay the same
         # even when data changes

--- a/pybleau/app/plotting/heatmap_factory.py
+++ b/pybleau/app/plotting/heatmap_factory.py
@@ -7,7 +7,7 @@ import logging
 from traits.api import Constant
 from chaco.api import ColorBar, DataRange1D, LinearMapper, PlotAxis
 
-from app_common.chaco.plot_factory import create_img_plot
+from app_common.chaco.plot_factory import create_contour_plot, create_img_plot
 
 from .plot_config import HEATMAP_PLOT_TYPE
 from .base_factories import DEFAULT_RENDERER_NAME, StdXYPlotFactory
@@ -59,9 +59,13 @@ class HeatmapPlotFactory(StdXYPlotFactory):
         self.plot_style.colorbar_high = z_arr.max()
 
     def add_renderers(self, plot):
+        if not len(self.plot_style.renderer_styles) == 1:
+            msg = "Only 1 renderer supported in image plots."
+            raise ValueError(msg)
+
         renderer_style = self.plot_style.renderer_styles[0]
         data = self.plot_data.get_data(TWO_D_DATA_NAME)
-        renderer = create_img_plot(data=data, cell_plot=True,
+        renderer = create_img_plot(data=data,
                                    **renderer_style.to_plot_kwargs())
         plot.add(renderer)
         plot.x_axis = PlotAxis(component=renderer,
@@ -106,9 +110,14 @@ class HeatmapPlotFactory(StdXYPlotFactory):
         renderer_style = self.plot_style.renderer_styles[0]
         xbounds = renderer_style.xbounds
         ybounds = renderer_style.ybounds
-        plot.contour_plot(TWO_D_DATA_NAME, type="line",
-                          xbounds=xbounds, ybounds=ybounds,
-                          levels=self.plot_style.contour_style.contour_levels,
-                          styles=self.plot_style.contour_style.contour_styles,
-                          widths=self.plot_style.contour_style.contour_widths,
-                          alpha=self.plot_style.contour_style.contour_alpha)
+
+        data = self.plot_data.get_data(TWO_D_DATA_NAME)
+        renderer = create_contour_plot(
+            data=data, type="line", xbounds=xbounds, ybounds=ybounds,
+            levels=self.plot_style.contour_style.contour_levels,
+            styles=self.plot_style.contour_style.contour_styles,
+            widths=self.plot_style.contour_style.contour_widths,
+            alpha=self.plot_style.contour_style.contour_alpha
+        )
+
+        plot.add(renderer)

--- a/pybleau/app/plotting/heatmap_factory.py
+++ b/pybleau/app/plotting/heatmap_factory.py
@@ -5,7 +5,9 @@ from __future__ import print_function, division
 import logging
 
 from traits.api import Constant
-from chaco.api import ColorBar, DataRange1D, LinearMapper
+from chaco.api import ColorBar, DataRange1D, LinearMapper, PlotAxis
+
+from app_common.chaco.plot_factory import create_img_plot
 
 from .plot_config import HEATMAP_PLOT_TYPE
 from .base_factories import DEFAULT_RENDERER_NAME, StdXYPlotFactory
@@ -58,9 +60,20 @@ class HeatmapPlotFactory(StdXYPlotFactory):
 
     def add_renderers(self, plot):
         renderer_style = self.plot_style.renderer_styles[0]
-        renderer = plot.img_plot(TWO_D_DATA_NAME,
-                                 **renderer_style.to_plot_kwargs())[0]
-        self.generate_colorbar(renderer, plot)
+        data = self.plot_data.get_data(TWO_D_DATA_NAME)
+        renderer = create_img_plot(data=data, cell_plot=True,
+                                   **renderer_style.to_plot_kwargs())
+        plot.add(renderer)
+        plot.x_axis = PlotAxis(component=renderer,
+                               orientation="bottom")
+        plot.y_axis = PlotAxis(component=renderer,
+                               orientation="left")
+        plot.underlays.append(plot.x_axis)
+        plot.underlays.append(plot.y_axis)
+
+        if self.plot_style.container_style.include_colorbar:
+            self.generate_colorbar(renderer, plot)
+
         if self.plot_style.contour_style.add_contours:
             self.generate_contours(plot)
 

--- a/pybleau/app/plotting/heatmap_plot_style.py
+++ b/pybleau/app/plotting/heatmap_plot_style.py
@@ -1,5 +1,5 @@
 
-from traits.api import Enum, Instance
+from traits.api import Bool, Enum, Instance
 from traitsui.api import HGroup, InstanceEditor, Item, VGroup
 
 from .plot_style import BaseColorXYPlotStyle, SPECIFIC_CONFIG_CONTROL_LABEL
@@ -13,6 +13,8 @@ class HeatmapPlotStyle(BaseColorXYPlotStyle):
     interpolation = Enum("nearest", "bilinear", "bicubic")
 
     contour_style = Instance(ContourStyle, ())
+
+    _second_y_axis_present = Bool
 
     def _get_specific_view_elements(self):
         return [

--- a/pybleau/app/plotting/histogram_factory.py
+++ b/pybleau/app/plotting/histogram_factory.py
@@ -6,7 +6,7 @@ from __future__ import print_function, division
 import numpy as np
 import logging
 
-from traits.api import Array, Constant, Instance, Int, Str
+from traits.api import Array, Constant, Instance, Str
 from chaco.api import ArrayPlotData
 
 from .plot_config import HIST_PLOT_TYPE

--- a/pybleau/app/plotting/histogram_factory.py
+++ b/pybleau/app/plotting/histogram_factory.py
@@ -35,19 +35,15 @@ class HistogramPlotFactory(StdXYPlotFactory):
     >>> x = array([1, 2, 3, 2])
     >>> h = HistogramPlotFactory("age", x)
     >>> h.generate_plot()
-    (<chaco.plot.Plot at 0x12278a590>,
-     {'ndim': 1,
-      'plot': <chaco.plot.Plot at 0x12278a590>,
-      ...})
+    {'plot': <chaco.plot.Plot at 0x12278a590>,
+     ...}
 
     Or a style object can be passed:
     >>> plot_style = HistogramPlotStyle(alpha=0.5)
     >>> h = HistogramPlotFactory("age", x, plot_style=plot_style)
     >>> h.generate_plot()
-    (<chaco.plot.Plot at 0x12278a590>,
-     {'ndim': 1,
-      'plot': <chaco.plot.Plot at 0x12278a590>,
-      ...})
+    {'plot': <chaco.plot.Plot at 0x12278a590>,
+     ...}
 
     FIXME: Make this class a subclass of the BarPlotFactory!
 
@@ -56,18 +52,13 @@ class HistogramPlotFactory(StdXYPlotFactory):
     #: Label to display along the y-axis
     y_axis_title = Str(HISTOGRAM_Y_LABEL)
 
-    #: Plot type as used by Plot.plot
-    plot_type_name = Constant("bar")
-
     #: String description of the type of plot this generates
     plot_type = Constant(HIST_PLOT_TYPE)
-
-    #: Number of DF columns involved in making the plot
-    ndim = Int(1)
 
     #: Edges of the histogram bars
     bin_edges = Array
 
+    #: Plot styling object
     plot_style = Instance(HistogramPlotStyle, ())
 
     def __init__(self, x_arr=None, **traits):
@@ -142,6 +133,3 @@ class HistogramPlotFactory(StdXYPlotFactory):
         """ Chaco histogram building helper: compute the bar widths.
         """
         return bar_width_factor * (bin_edges[-1] - bin_edges[0]) / num_bins
-
-    def _plot_tools_default(self):
-        return {"zoom", "pan"}

--- a/pybleau/app/plotting/histogram_factory.py
+++ b/pybleau/app/plotting/histogram_factory.py
@@ -50,6 +50,8 @@ class HistogramPlotFactory(StdXYPlotFactory):
       ...})
 
     FIXME: Make this class a subclass of the BarPlotFactory!
+
+    TODO: support displaying a histogram for multiple datasets.
     """
     #: Label to display along the y-axis
     y_axis_title = Str(HISTOGRAM_Y_LABEL)

--- a/pybleau/app/plotting/line_factory.py
+++ b/pybleau/app/plotting/line_factory.py
@@ -1,30 +1,12 @@
 """ See base class module for general documentation on factories.
 """
-from __future__ import print_function, division
-
-import logging
-
 from traits.api import Constant
 from .plot_config import LINE_PLOT_TYPE
 from .base_factories import StdXYPlotFactory
 
-BAR_SQUEEZE_FACTOR = 0.8
-
-ERROR_BAR_COLOR = "black"
-
-ERROR_BAR_DATA_KEY_PREFIX = "__error_"
-
-logger = logging.getLogger(__name__)
-
 
 class LinePlotFactory(StdXYPlotFactory):
-    """ Factory to build a line plot.
+    """ Factory to build an XY plot containing line plot.
     """
-    #: Plot type as used by Plot.plot
-    plot_type_name = Constant("line")
-
     #: Plot type as selected by user
     plot_type = Constant(LINE_PLOT_TYPE)
-
-    def _plot_tools_default(self):
-        return {"zoom", "pan", "legend"}

--- a/pybleau/app/plotting/multi_plot_config.py
+++ b/pybleau/app/plotting/multi_plot_config.py
@@ -119,8 +119,8 @@ class MultiLinePlotConfigurator(BaseSingleXYPlotConfigurator,
                 colorize_by_float=False
             )
             config_list = [self]
-            self.y_axis_title = ", ".join([col_name_to_title(y)
-                                           for y in self.y_col_names])
+            self.y_axis_title = "auto"
+            self.second_y_axis_title = "auto"
 
         return config_list
 

--- a/pybleau/app/plotting/multi_plot_config.py
+++ b/pybleau/app/plotting/multi_plot_config.py
@@ -119,8 +119,8 @@ class MultiLinePlotConfigurator(BaseSingleXYPlotConfigurator,
                 colorize_by_float=False
             )
             config_list = [self]
-            self.y_axis_title = "auto"
-            self.second_y_axis_title = "auto"
+            self.y_axis_title = ", ".join(self.y_col_names)
+            self.second_y_axis_title = ""
 
         return config_list
 
@@ -143,7 +143,7 @@ class MultiLinePlotConfigurator(BaseSingleXYPlotConfigurator,
 
 
 class MultiHistogramPlotConfigurator(BaseMultiPlotConfigurator):
-    """ Configurator to create multiple histograms.
+    """ Configurator to create multiple histograms (in multiple containers).
     """
     #: Type of the series of plots being created
     plot_type = Constant(MULTI_HIST_PLOT_TYPE)

--- a/pybleau/app/plotting/plot_config.py
+++ b/pybleau/app/plotting/plot_config.py
@@ -168,6 +168,12 @@ class BaseSinglePlotConfigurator(BasePlotConfigurator):
     #: Title to display along the y-axis
     y_axis_title = Str
 
+    #: Column name(s) to display along the secondary y-axis
+    second_y_col_name = Str
+
+    #: Title to display along the secondary y-axis
+    second_y_axis_title = Str
+
     #: Title to display along the z-axis
     z_axis_title = Str
 
@@ -385,7 +391,8 @@ class BaseSingleXYPlotConfigurator(BaseSinglePlotConfigurator):
     def __dict_keys_default(self):
         return ["plot_title", "x_col_name", "y_col_name", "z_col_name",
                 "x_axis_title", "y_axis_title", "z_axis_title", "x_arr",
-                "y_arr", "z_arr", "hover_data", "hover_col_names"]
+                "y_arr", "z_arr", "hover_data", "hover_col_names",
+                "second_y_col_name", "second_y_axis_title"]
 
 
 class BarPlotConfigurator(BaseSingleXYPlotConfigurator):

--- a/pybleau/app/plotting/plot_config.py
+++ b/pybleau/app/plotting/plot_config.py
@@ -599,6 +599,8 @@ class ScatterPlotConfigurator(BaseSingleXYPlotConfigurator):
         style = BaseColorXYPlotStyle(colorize_by_float=self.colorize_by_float)
         style.renderer_styles = [self.renderer_style_klass()
                                  for _ in range(num_renderer)]
+        if self.colorize_by_float:
+            style.container_style.include_colorbar = True
         return style
 
 
@@ -648,7 +650,7 @@ class HeatmapPlotConfigurator(BaseSingleXYPlotConfigurator):
     """
     plot_type = Constant(HEATMAP_PLOT_TYPE)
 
-    plot_style = Instance(HeatmapPlotStyle, ())
+    plot_style = Instance(HeatmapPlotStyle)
 
     def traits_view(self):
         enum_data_columns = EnumEditor(values=self._available_columns)
@@ -692,6 +694,11 @@ class HeatmapPlotConfigurator(BaseSingleXYPlotConfigurator):
         return self.data_source.pivot_table(index=self.y_col_name,
                                             columns=self.x_col_name,
                                             values=self.z_col_name).values
+
+    def _plot_style_default(self):
+        style = HeatmapPlotStyle()
+        style.container_style.include_colorbar = True
+        return style
 
 
 def col_name_to_title(col_name):

--- a/pybleau/app/plotting/plot_container_style.py
+++ b/pybleau/app/plotting/plot_container_style.py
@@ -18,12 +18,15 @@ class PlotContainerStyle(HasStrictTraits):
     padding_bottom = Int(20)
 
     # Is the border visible?
-    border_visible = Bool(True)
+    border_visible = Bool(False)
 
     # The background color of the plot
     bgcolor = white_color_trait
 
-    def to_opc_traits(self):
+    #: Whether to show a colorbar (if relevant)
+    include_colorbar = Bool
+
+    def to_traits(self):
         """ Build OverlayPlotContainer construction keyword list.
         """
         return {

--- a/pybleau/app/plotting/plot_container_style.py
+++ b/pybleau/app/plotting/plot_container_style.py
@@ -1,0 +1,36 @@
+
+from traits.api import Bool, HasStrictTraits, Int
+from enable.component import white_color_trait
+
+
+class PlotContainerStyle(HasStrictTraits):
+
+    #: The amount of space to put on the left side of the component
+    padding_left = Int(20)
+
+    #: The amount of space to put on the right side of the component
+    padding_right = Int(20)
+
+    #: The amount of space to put on top of the component
+    padding_top = Int(30)
+
+    #: The amount of space to put below the component
+    padding_bottom = Int(20)
+
+    # Is the border visible?
+    border_visible = Bool(True)
+
+    # The background color of the plot
+    bgcolor = white_color_trait
+
+    def to_opc_traits(self):
+        """ Build OverlayPlotContainer construction keyword list.
+        """
+        return {
+            "padding_left": self.padding_left,
+            "padding_right": self.padding_right,
+            "padding_top": self.padding_top,
+            "padding_bottom": self.padding_bottom,
+            "border_visible": self.border_visible,
+            "bgcolor": self.bgcolor
+        }

--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -195,7 +195,8 @@ class BaseXYPlotStyle(HasTraits):
                 VGroup(*items,
                        show_border=True, label="Renderer controls"),
                 VGroup(
-                    Item("container_style"),
+                    Item("container_style", editor=InstanceEditor(),
+                         style="custom", show_label=False),
                     show_border=True, label="Container controls"
                 )
             )

--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -3,8 +3,8 @@
 """
 import logging
 
-from traits.api import Any, Bool, Dict, Enum, Float, HasTraits, Instance, \
-    List, on_trait_change, Property
+from traits.api import Any, Bool, Callable, Dict, Enum, Float, HasTraits, \
+    Instance, List, on_trait_change, Property
 from traitsui.api import HGroup, InstanceEditor, Item, \
     OKCancelButtons, Tabbed, VGroup, View
 
@@ -64,7 +64,7 @@ class BaseXYPlotStyle(HasTraits):
     view_kw = Dict
 
     #: Range value transformation function for eg. to avoid non-sensical digits
-    _range_transform = Any
+    range_transform = Callable
 
     def initialize_axis_ranges(self, plot, x_mapper=None, y_mapper=None,
                                second_y_mapper=None):
@@ -75,7 +75,7 @@ class BaseXYPlotStyle(HasTraits):
             second_y_mapper=second_y_mapper
         )
 
-        transform = self._range_transform
+        transform = self.range_transform
 
         if x_mapper:
             x_axis_style = self.x_axis_style
@@ -97,7 +97,7 @@ class BaseXYPlotStyle(HasTraits):
     def _init_second_y_axis_style_range(self, second_y_mapper):
         """ Initialize the secondary y axis range.
         """
-        transform = self._range_transform
+        transform = self.range_transform
 
         second_y_axis_style = self.second_y_axis_style
         second_y_axis_style.range_low = transform(second_y_mapper.range.low)
@@ -270,10 +270,8 @@ class BaseXYPlotStyle(HasTraits):
             title="Plot Styling",
         )
 
-    def __range_transform_default(self):
-        def transform(x):
-            return x
-        return transform
+    def _range_transform_default(self):
+        return lambda x: x
 
 
 class BaseColorXYPlotStyle(BaseXYPlotStyle):

--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -7,7 +7,6 @@ from traits.api import Any, Bool, Dict, Enum, Float, HasTraits, Instance, \
     List, on_trait_change, Property
 from traitsui.api import HGroup, InstanceEditor, Item, \
     OKCancelButtons, Tabbed, VGroup, View
-from chaco.api import Plot
 
 from ..utils.chaco_colors import ALL_MPL_PALETTES
 from .axis_style import AxisStyle
@@ -16,7 +15,7 @@ from .renderer_style import BaseRendererStyle, LineRendererStyle, \
     ScatterRendererStyle
 from ..utils.chaco_colors import generate_chaco_colors
 from ..utils.string_definitions import DEFAULT_DIVERG_PALETTE
-
+from .plot_container_style import PlotContainerStyle
 
 SPECIFIC_CONFIG_CONTROL_LABEL = "Specific controls"
 
@@ -36,11 +35,21 @@ class BaseXYPlotStyle(HasTraits):
     #: Font used to draw the plot title
     title_style = Instance(TitleStyle, ())
 
+    #: Styling for the plot container
+    container_style = Instance(PlotContainerStyle, ())
+
     #: Styling elements for the x-axis
     x_axis_style = Instance(AxisStyle)
 
-    #: Styling elements for the x-axis
+    #: Styling elements for the y-axis
     y_axis_style = Instance(AxisStyle)
+
+    #: Styling elements for the secondary y-axis
+    second_y_axis_style = Instance(AxisStyle)
+
+    #: Whether there is a renderer to be displayed on the secondary y-axis
+    _second_y_axis_present = Property(Bool,
+                                      depends_on="renderer_styles.orientation")
 
     #: View klass. Override to customize the view, for example its icon
     view_klass = Any(default_value=View)
@@ -54,53 +63,88 @@ class BaseXYPlotStyle(HasTraits):
     #: Keywords passed to create the view
     view_kw = Dict
 
+    #: Range value transformation function for eg. to avoid non-sensical digits
+    _range_transform = Any
+
     def initialize_axis_ranges(self, plot, x_mapper=None, y_mapper=None,
-                               transform=None):
-        """ Initialize the axis ranges from provided Plot or renderer.
+                               second_y_mapper=None):
+        """ Initialize all axis ranges from provided Plot (container).
         """
-        if transform is None:
-            def transform(x):
-                return x
+        x_mapper, y_mapper, second_y_mapper = self._get_plot_mappers(
+            plot, x_mapper=x_mapper, y_mapper=y_mapper,
+            second_y_mapper=second_y_mapper
+        )
 
-        elif isinstance(transform, int):
-            ndigits = transform
+        transform = self._range_transform
 
-            def transform(x):
-                return round(x, ndigits)
-
-        if x_mapper is None:
-            if isinstance(plot, Plot):
-                x_mapper = plot.x_axis.mapper
-            else:
-                msg = "Unsupported plot type: {}".format(type(plot))
-                logger.exception(msg)
-                raise ValueError(msg)
-
-        if y_mapper is None:
-            if isinstance(plot, Plot):
-                y_mapper = plot.y_axis.mapper
-            else:
-                msg = "Unsupported plot type: {}".format(type(plot))
-                logger.exception(msg)
-                raise ValueError(msg)
-
-        # Apply transform for e.g. to avoid polluting UI w/ non-sensical digits
         if x_mapper:
-            self.x_axis_style.range_low = transform(x_mapper.range.low)
-            self.x_axis_style.auto_range_low = self.x_axis_style.range_low
-            self.x_axis_style.range_high = transform(x_mapper.range.high)
-            self.x_axis_style.auto_range_high = self.x_axis_style.range_high
+            x_axis_style = self.x_axis_style
+            x_axis_style.range_low = transform(x_mapper.range.low)
+            x_axis_style.auto_range_low = x_axis_style.range_low
+            x_axis_style.range_high = transform(x_mapper.range.high)
+            x_axis_style.auto_range_high = x_axis_style.range_high
+
         if y_mapper:
-            self.y_axis_style.range_low = transform(y_mapper.range.low)
-            self.y_axis_style.auto_range_low = self.y_axis_style.range_low
-            self.y_axis_style.range_high = transform(y_mapper.range.high)
-            self.y_axis_style.auto_range_high = self.y_axis_style.range_high
+            y_axis_style = self.y_axis_style
+            y_axis_style.range_low = transform(y_mapper.range.low)
+            y_axis_style.auto_range_low = y_axis_style.range_low
+            y_axis_style.range_high = transform(y_mapper.range.high)
+            y_axis_style.auto_range_high = y_axis_style.range_high
+
+        if second_y_mapper:
+            self._init_second_y_axis_style_range(second_y_mapper)
+
+    def _init_second_y_axis_style_range(self, second_y_mapper):
+        """ Initialize the secondary y axis range.
+        """
+        transform = self._range_transform
+
+        second_y_axis_style = self.second_y_axis_style
+        second_y_axis_style.range_low = transform(second_y_mapper.range.low)
+        second_y_axis_style.auto_range_low = second_y_axis_style.range_low
+        second_y_axis_style.range_high = transform(second_y_mapper.range.high)
+        second_y_axis_style.auto_range_high = second_y_axis_style.range_high
+
+    def apply_axis_ranges(self, plot, x_mapper=None, y_mapper=None,
+                          second_y_mapper=None):
+        """ Apply to the plot's mappers the ranges stored in this style object.
+        """
+        x_mapper, y_mapper, second_y_mapper = self._get_plot_mappers(
+            plot, x_mapper=x_mapper, y_mapper=y_mapper,
+            second_y_mapper=second_y_mapper
+        )
+
+        x_mapper.range.low = self.x_axis_style.range_low
+        x_mapper.range.high = self.x_axis_style.range_high
+        y_mapper.range.low = self.y_axis_style.range_low
+        y_mapper.range.high = self.y_axis_style.range_high
+
+        if second_y_mapper:
+            second_y_axis_style = self.second_y_axis_style
+            sec_low = second_y_axis_style.range_low
+            sec_high = second_y_axis_style.range_high
+            if sec_low == sec_high:
+                # It was never initialized:
+                self._init_second_y_axis_style_range(second_y_mapper)
+            else:
+                second_y_mapper.range.low = second_y_axis_style.range_low
+                second_y_mapper.range.high = second_y_axis_style.range_high
+
+    def traits_view(self):
+        view = self.view_klass(
+            *self.view_elements,
+            **self.view_kw
+        )
+        return view
 
     # Traits property getter/setter -------------------------------------------
 
-    def traits_view(self):
-        view = self.view_klass(*self.view_elements, **self.view_kw)
-        return view
+    def _get__second_y_axis_present(self):
+        for style in self.renderer_styles:
+            if style.orientation == "right":
+                return True
+
+        return False
 
     def _get_specific_view_elements(self):
         return []
@@ -140,13 +184,25 @@ class BaseXYPlotStyle(HasTraits):
                              style="custom", show_label=False),
                         show_border=True, label="Y-axis controls"
                     ),
+                    VGroup(
+                        Item("second_y_axis_style", editor=InstanceEditor(),
+                             style="custom", show_label=False),
+                        show_border=True, label="Secondary Y-axis controls",
+                        visible_when="_second_y_axis_present"
+                    ),
                     show_border=True, label="Axis controls"
                 ),
                 VGroup(*items,
                        show_border=True, label="Renderer controls"),
+                VGroup(
+                    Item("container_style"),
+                    show_border=True, label="Container controls"
+                )
             )
         ]
         return elemens
+
+    # Private interface -------------------------------------------------------
 
     @staticmethod
     def _make_group_for_renderer(trait_name, renderer_name=""):
@@ -167,6 +223,34 @@ class BaseXYPlotStyle(HasTraits):
             show_border=True, label=renderer_name
         )
 
+    def _get_plot_mappers(self, plot, x_mapper=None, y_mapper=None,
+                          second_y_mapper=None):
+        """ Retrieve the plot's mappers to synchronize with the style.
+        """
+        missing_mapper_msg = "The plot is missing the attribute {}. Please " \
+                             "provide the mapper explicitly"
+        if x_mapper is None:
+            if hasattr(plot, "x_axis"):
+                x_mapper = plot.x_axis.mapper
+            else:
+                msg = missing_mapper_msg.format("x_axis")
+                logger.exception(msg)
+                raise ValueError(msg)
+
+        if y_mapper is None:
+            if hasattr(plot, "y_axis"):
+                y_mapper = plot.y_axis.mapper
+            else:
+                msg = missing_mapper_msg.format("y_axis")
+                logger.exception(msg)
+                raise ValueError(msg)
+
+        if second_y_mapper is None:
+            if hasattr(plot, "second_y_axis"):
+                second_y_mapper = plot.second_y_axis.mapper
+
+        return x_mapper, y_mapper, second_y_mapper
+
     # Traits initialization methods -------------------------------------------
 
     def _x_axis_style_default(self):
@@ -175,12 +259,20 @@ class BaseXYPlotStyle(HasTraits):
     def _y_axis_style_default(self):
         return AxisStyle(axis_name="Y")
 
+    def _second_y_axis_style_default(self):
+        return AxisStyle(axis_name="Second. Y")
+
     def _view_kw_default(self):
         return dict(
             resizable=True,
             buttons=OKCancelButtons,
             title="Plot Styling",
         )
+
+    def __range_transform_default(self):
+        def transform(x):
+            return x
+        return transform
 
 
 class BaseColorXYPlotStyle(BaseXYPlotStyle):

--- a/pybleau/app/plotting/renderer_style.py
+++ b/pybleau/app/plotting/renderer_style.py
@@ -33,13 +33,21 @@ class BaseRendererStyle(HasStrictTraits):
     view_klass = Any(default_value=View)
 
     #: List of attributes to convert to kwargs for the Plot.plot method
-    dict_keys = List(Str)
+    dict_keys = List
 
     def to_plot_kwargs(self):
         """ Supports converting renderer styles into a dict of kwargs for the
-        Plot.plot() method.
+        renderer factory function/method.
         """
-        return {key: getattr(self, key) for key in self.dict_keys}
+        kwargs = {}
+        for key in self.dict_keys:
+            if isinstance(key, tuple):
+                key, target_key = key
+            else:
+                target_key = key
+
+            kwargs[target_key] = getattr(self, key)
+        return kwargs
 
 
 class BaseXYRendererStyle(BaseRendererStyle):
@@ -168,8 +176,8 @@ class LineRendererStyle(BaseXYRendererStyle):
         view = self.view_klass(
             VGroup(
                 HGroup(
-                    Item('line_width'),
-                    Item('line_style', style="custom"),
+                    Item('line_width', label="Line width"),
+                    Item('line_style', label="Line style", style="custom"),
                 ),
                 *self.general_view_elements
             ),
@@ -178,7 +186,8 @@ class LineRendererStyle(BaseXYRendererStyle):
 
     def _dict_keys_default(self):
         general_items = super(LineRendererStyle, self)._dict_keys_default()
-        return general_items + ["line_width", "line_style"]
+        new = [("line_width", "width"), ("line_style", "dash")]
+        return general_items + new
 
 
 class BarRendererStyle(BaseXYRendererStyle):

--- a/pybleau/app/plotting/renderer_style.py
+++ b/pybleau/app/plotting/renderer_style.py
@@ -15,6 +15,16 @@ DEFAULT_MARKER_SIZE = 6
 
 DEFAULT_LINE_WIDTH = 1.3
 
+STYLE_L_ORIENT = "left"
+
+STYLE_R_ORIENT = "right"
+
+REND_TYPE_LINE = "line"
+
+REND_TYPE_SCAT = "scatter"
+
+REND_TYPE_CMAP_SCAT = "cmap_scatter"
+
 
 class BaseRendererStyle(HasStrictTraits):
     """ Styling object for customizing scatter renderers.
@@ -60,7 +70,7 @@ class BaseXYRendererStyle(BaseRendererStyle):
     alpha = Range(value=1., low=0., high=1.)
 
     #: Which y-axis to be displayed along
-    orientation = Enum(["left", "right"])
+    orientation = Enum([STYLE_L_ORIENT, STYLE_R_ORIENT])
 
     def traits_view(self):
         view = self.view_klass(
@@ -92,7 +102,7 @@ class ScatterRendererStyle(BaseXYRendererStyle):
     """ Styling object for customizing scatter renderers.
     """
     #: Name of the renderer type, as understood by `chaco.Plot.plot()`.
-    renderer_type = "scatter"
+    renderer_type = REND_TYPE_SCAT
 
     #: The type of marker to use
     marker = Trait("circle", MarkerNameDict,
@@ -122,7 +132,7 @@ class ScatterRendererStyle(BaseXYRendererStyle):
 class CmapScatterRendererStyle(ScatterRendererStyle):
 
     #: Name of the renderer type, as understood by `chaco.Plot.plot()`.
-    renderer_type = "cmap_scatter"
+    renderer_type = REND_TYPE_CMAP_SCAT
 
     #: Name of the palette to pick colors from in z direction
     color_palette = Enum(ALL_CHACO_PALETTES)
@@ -166,7 +176,7 @@ class CmapScatterRendererStyle(ScatterRendererStyle):
 class LineRendererStyle(BaseXYRendererStyle):
     """ Styling object for customizing line renderers.
     """
-    renderer_type = "line"
+    renderer_type = REND_TYPE_LINE
 
     line_width = Float(DEFAULT_LINE_WIDTH)
 

--- a/pybleau/app/plotting/renderer_style.py
+++ b/pybleau/app/plotting/renderer_style.py
@@ -29,7 +29,7 @@ REND_TYPE_CMAP_SCAT = "cmap_scatter"
 class BaseRendererStyle(HasStrictTraits):
     """ Styling object for customizing scatter renderers.
     """
-    #: Name of the renderer type, as understood by `chaco.Plot.plot()`.
+    #: Name of the renderer type, used to select the renderer factory.
     renderer_type = ""
 
     #: Name of the renderer as referenced in the plot container.
@@ -71,14 +71,6 @@ class BaseXYRendererStyle(BaseRendererStyle):
 
     #: Which y-axis to be displayed along
     orientation = Enum([STYLE_L_ORIENT, STYLE_R_ORIENT])
-
-    def traits_view(self):
-        view = self.view_klass(
-            VGroup(
-                *self.general_view_elements
-            ),
-        )
-        return view
 
     # Traits property getter/setter -------------------------------------------
 

--- a/pybleau/app/plotting/scatter_factories.py
+++ b/pybleau/app/plotting/scatter_factories.py
@@ -15,7 +15,7 @@ from app_common.chaco.scatter_position_tool import add_scatter_inspectors, \
     DataframeScatterInspector
 from app_common.chaco.plot_factory import create_cmap_scatter_plot
 
-from .plot_config import SCATTER_PLOT_TYPE
+from .plot_config import CMAP_SCATTER_PLOT_TYPE, SCATTER_PLOT_TYPE
 from .renderer_style import REND_TYPE_CMAP_SCAT
 from .base_factories import StdXYPlotFactory
 
@@ -111,6 +111,9 @@ class CmapScatterPlotFactory(ScatterPlotFactory):
         scatter renderers, for example when colorizing using a column of
         discrete values.
     """
+    #: Plot type as selected by user
+    plot_type = Constant(CMAP_SCATTER_PLOT_TYPE)
+
     def generate_colorbar(self, desc):
         """ Generate the colorbar to display along side the plot.
         """

--- a/pybleau/app/plotting/scatter_factories.py
+++ b/pybleau/app/plotting/scatter_factories.py
@@ -29,10 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class ScatterPlotFactory(StdXYPlotFactory):
-    """ Factory to build a scatter plot.
-
-    It supports creating a plot with any number of scatter renderers, including
-    single-colored renderers.
+    """ Factory to build a potentially multi-renderer XY plot.
 
     This plot currently supports displaying many dimensions at once since it
     supports a legend tool to select parts of the data and a hover tool to
@@ -103,6 +100,16 @@ class ScatterPlotFactory(StdXYPlotFactory):
         add_scatter_inspectors(plot, datasets=renderer_data,
                                include_overlay=True, align="ul")
 
+    def update_renderer_from_data(self):
+        """ The plot_data was updated: update all renderers with the new data.
+        """
+        # Update exist
+        super(ScatterPlotFactory, self).update_renderer_from_data()
+
+        # Add new renderers as needed:
+
+        # Remove renderers as needed:
+
 
 class CmapScatterPlotFactory(ScatterPlotFactory):
     """ Factory to build a single scatter plot colormapped by a z array.
@@ -122,8 +129,13 @@ class CmapScatterPlotFactory(ScatterPlotFactory):
         return {"zoom", "pan", "click_selector", "colorbar_selector", "hover"}
 
     def add_colorbar(self, desc):
-        # FIXME: consolidate this and the base class implementation
+        """ Modify the descriptor's plot entry to add a color bar to it.
 
+        This is done by embedding the plot into an HPlotContainer and adding a
+        colorbar plot to the right.
+
+        FIXME: consolidate this and the base class implementation
+        """
         plot = desc["plot"]
         styles = self.plot_style.renderer_styles
         renderers = self.renderers.values()
@@ -163,7 +175,7 @@ class CmapScatterPlotFactory(ScatterPlotFactory):
         container.add(plot, colorbar)
         desc["plot"] = container
 
-    def build_renderer(self, desc, style):
+    def _build_renderer(self, desc, style):
         x = self.plot_data.get_data(desc["x"])
         y = self.plot_data.get_data(desc["y"])
         z = self.plot_data.get_data(desc["z"])

--- a/pybleau/app/plotting/scatter_factories.py
+++ b/pybleau/app/plotting/scatter_factories.py
@@ -8,7 +8,7 @@ import logging
 
 from traits.api import Constant, Tuple
 from chaco.api import ArrayPlotData, ColorBar, ColormappedSelectionOverlay, \
-    HPlotContainer, LinearMapper, ScatterInspectorOverlay
+    LinearMapper, ScatterInspectorOverlay
 from chaco.tools.api import RangeSelection, RangeSelectionOverlay
 
 from app_common.chaco.scatter_position_tool import add_scatter_inspectors, \
@@ -35,17 +35,11 @@ class ScatterPlotFactory(StdXYPlotFactory):
     supports a legend tool to select parts of the data and a hover tool to
     display any number of additional columns.
     """
-    #: Plot type as used by Plot.plot
-    plot_type_name = Constant("scatter")
-
     #: Plot type as selected by user
     plot_type = Constant(SCATTER_PLOT_TYPE)
 
     #: Inspector tool and overlay to query/listen to for events
     inspector = Tuple
-
-    def _plot_tools_default(self):
-        return {"zoom", "pan", "click_selector", "legend", "hover"}
 
     def add_tools(self, plot):
         super(ScatterPlotFactory, self).add_tools(plot)
@@ -100,15 +94,11 @@ class ScatterPlotFactory(StdXYPlotFactory):
         add_scatter_inspectors(plot, datasets=renderer_data,
                                include_overlay=True, align="ul")
 
-    def update_renderer_from_data(self):
-        """ The plot_data was updated: update all renderers with the new data.
-        """
-        # Update exist
-        super(ScatterPlotFactory, self).update_renderer_from_data()
+    # Traits initialization methods -------------------------------------------
 
-        # Add new renderers as needed:
-
-        # Remove renderers as needed:
+    def _plot_tools_default(self):
+        base_tools = super(ScatterPlotFactory, self)._plot_tools_default()
+        return base_tools | {"click_selector", "hover"}
 
 
 class CmapScatterPlotFactory(ScatterPlotFactory):
@@ -121,13 +111,6 @@ class CmapScatterPlotFactory(ScatterPlotFactory):
         scatter renderers, for example when colorizing using a column of
         discrete values.
     """
-    #: Plot type as used by Plot.plot
-    plot_type_name = Constant("cmap_scatter")
-
-    def _plot_tools_default(self):
-        # No need for a legend
-        return {"zoom", "pan", "click_selector", "colorbar_selector", "hover"}
-
     def generate_colorbar(self, desc):
         """ Generate the colorbar to display along side the plot.
         """
@@ -199,6 +182,11 @@ class CmapScatterPlotFactory(ScatterPlotFactory):
                                       for col in self.hover_col_names})
         add_scatter_inspectors(plot, datasets=renderer_data,
                                include_overlay=True, align="ul")
+
+    # Traits initialization methods -------------------------------------------
+
+    def _plot_tools_default(self):
+        return {"zoom", "pan", "click_selector", "colorbar_selector", "hover"}
 
 
 def create_cmap_scatter_colorbar(color_mapper, select_tool=False):

--- a/pybleau/app/plotting/scatter_factories.py
+++ b/pybleau/app/plotting/scatter_factories.py
@@ -58,8 +58,7 @@ class ScatterPlotFactory(StdXYPlotFactory):
     def add_click_selector_tool(self, plot):
         """ Add scatter point click tool to select points.
         """
-        for i, renderer_name in enumerate(plot.plots):
-            renderer = plot.plots[renderer_name][0]
+        for i, renderer in enumerate(plot.components):
             marker_size = self.plot_style.renderer_styles[i].marker_size
             marker = self.plot_style.renderer_styles[i].marker
             inspector_tool = DataframeScatterInspector(

--- a/pybleau/app/plotting/scatter_factories.py
+++ b/pybleau/app/plotting/scatter_factories.py
@@ -128,13 +128,8 @@ class CmapScatterPlotFactory(ScatterPlotFactory):
         # No need for a legend
         return {"zoom", "pan", "click_selector", "colorbar_selector", "hover"}
 
-    def add_colorbar(self, desc):
-        """ Modify the descriptor's plot entry to add a color bar to it.
-
-        This is done by embedding the plot into an HPlotContainer and adding a
-        colorbar plot to the right.
-
-        FIXME: consolidate this and the base class implementation
+    def generate_colorbar(self, desc):
+        """ Generate the colorbar to display along side the plot.
         """
         plot = desc["plot"]
         styles = self.plot_style.renderer_styles
@@ -158,7 +153,7 @@ class CmapScatterPlotFactory(ScatterPlotFactory):
                                                     selection_type="mask")
             cmap_renderer.overlays.append(selection)
 
-        # Add a colorbar:
+        # Create the actual colorbar:
 
         colorbar = create_cmap_scatter_colorbar(cmap_renderer.color_mapper,
                                                 select_tool=select_tool)
@@ -166,14 +161,7 @@ class CmapScatterPlotFactory(ScatterPlotFactory):
         colorbar.title = self.z_axis_title
         colorbar.padding_top = plot.padding_top
         colorbar.padding_bottom = plot.padding_bottom
-
-        # Create a container to position the plot and the colorbar side-by-side
-        container_traits = self.plot_style.container_style.to_traits()
-        container_traits["bgcolor"] = "transparent"
-        container_traits["border_visible"] = False
-        container = HPlotContainer(use_backbuffer=True, **container_traits)
-        container.add(plot, colorbar)
-        desc["plot"] = container
+        self.colorbar = colorbar
 
     def _build_renderer(self, desc, style):
         x = self.plot_data.get_data(desc["x"])

--- a/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
+++ b/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_almost_equal
 from traits.testing.unittest_tools import UnittestTools
 
 try:
-    from chaco.api import BarPlot, LinePlot, Plot, PlotGraphicsContext, \
+    from chaco.api import BarPlot, LinePlot, PlotGraphicsContext, \
         ScatterInspectorOverlay, ScatterPlot
     from chaco.tools.api import BetterSelectingZoom
     from chaco.tools.broadcaster import BroadcasterTool
@@ -36,8 +36,6 @@ try:
     from pybleau.app.plotting.histogram_plot_style import HistogramPlotStyle
     from pybleau.app.plotting.plot_config import BarPlotConfigurator, \
         HeatmapPlotConfigurator, LinePlotConfigurator, ScatterPlotConfigurator
-    from pybleau.app.plotting.multi_plot_config import \
-        MultiLinePlotConfigurator
     from pybleau.app.plotting.plot_style import BaseColorXYPlotStyle, \
         LineRendererStyle
 

--- a/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
+++ b/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
@@ -1103,7 +1103,7 @@ class TestMakeHeatmapPlot(BaseTestMakePlot, TestCase):
         self.assertEqual(len(main_plot.components), num_renderers)
         self.assertIsInstance(main_plot.components[0], self.renderer_class)
         if with_contours:
-            self.assertIsInstance(main_plot.plots["plot1"][0], ContourLinePlot)
+            self.assertIsInstance(main_plot.components[1], ContourLinePlot)
 
 
 class BaseScatterPlotTools(object):

--- a/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
+++ b/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
@@ -1157,10 +1157,7 @@ class BaseScatterPlotTools(object):
         self.assertIn("pan", factory.plot_tools)
         self.assertIn("zoom", factory.plot_tools)
 
-        try:
-            first_renderer = plot.components[0]
-        except Exception:
-            import pdb ; pdb.set_trace()
+        first_renderer = plot.components[0]
 
         # tools added to renderers via the broadcaster tool:
         self.assertGreaterEqual(len(first_renderer.tools), 1)

--- a/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
+++ b/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
@@ -10,8 +10,10 @@ from traits.testing.unittest_tools import UnittestTools
 try:
     from chaco.api import BarPlot, LinePlot, Plot, PlotGraphicsContext, \
         ScatterInspectorOverlay, ScatterPlot
+    from chaco.tools.api import BetterSelectingZoom
+    from chaco.tools.broadcaster import BroadcasterTool
     from chaco.color_mapper import ColorMapper
-    from chaco.plot_containers import HPlotContainer
+    from chaco.plot_containers import HPlotContainer, OverlayPlotContainer
     from chaco.color_bar import ColorBar
     from chaco.cmap_image_plot import CMapImagePlot
     from chaco.contour_line_plot import ContourLinePlot
@@ -75,34 +77,30 @@ class BaseTestMakePlot(object):
 
     # Helpers -----------------------------------------------------------------
 
-    def assert_valid_plot(self, plot, desc, num_renderers=1, main_renderer="",
-                          test_view=True):
+    def assert_valid_plot(self, plot, desc, num_renderers=1, renderer_name="",
+                          factory=None, test_view=True):
         if isinstance(plot, HPlotContainer):
             is_cmapped = True
             colorbar = plot.plot_components[1]
             self.assertIsInstance(colorbar, ColorBar)
             self.assertIsInstance(colorbar.color_mapper, ColorMapper)
-            plot = plot.plot_components[0]
+            plot = plot.components[0]
         else:
             is_cmapped = False
 
-        self.assertIsInstance(plot, Plot)
+        self.assertIsInstance(plot, OverlayPlotContainer)
         self.assertIsInstance(desc, dict)
-        self.assertIs(desc["plot"], plot)
         if not is_cmapped:
             self.assertEqual(desc["plot_type"], self.type)
 
         self.assertTrue(desc['visible'])
-        self.assertEqual(len(plot.plots), num_renderers)
-        for plot_list in plot.plots.values():
-            self.assertEqual(len(plot_list), 1)
-
-        if not main_renderer:
-            main_renderer = list(plot.plots.values())[0][0]
+        self.assertEqual(len(plot.components), num_renderers)
+        if not renderer_name:
+            renderer = plot.components[0]
         else:
-            main_renderer = plot.plots[main_renderer][0]
+            renderer = factory.renderers[renderer_name]
 
-        self.assertIsInstance(main_renderer, self.renderer_class)
+        self.assertIsInstance(renderer, self.renderer_class)
 
         if test_view:
             # Test that we can bring that plot up in a UI:
@@ -123,7 +121,8 @@ class TestMakeHistogramPlot(BaseTestMakePlot, TestCase):
     def test_histogram_simple_array(self):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=TEST_DF["a"],
                                           **self.hist_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
         self.assertEqual(len(plot.data.arrays['a']), 10)
         self.assertAlmostEqual(plot.data.arrays['a'][0], 1.15)
@@ -133,7 +132,8 @@ class TestMakeHistogramPlot(BaseTestMakePlot, TestCase):
         self.hist_kw['plot_style'].num_bins = 20
         factory = self.plot_factory_klass(x_col_name="a", x_arr=TEST_DF["a"],
                                           **self.hist_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
         self.assertEqual(len(plot.data.arrays['a']), 20)
 
@@ -141,7 +141,8 @@ class TestMakeHistogramPlot(BaseTestMakePlot, TestCase):
         self.hist_kw['plot_style'].bin_limits = (0, 10)
         factory = self.plot_factory_klass(x_col_name="a", x_arr=TEST_DF["a"],
                                           **self.hist_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
         # Range change
         self.assertAlmostEqual(plot.data.arrays['a'][0], 0.5)
@@ -150,12 +151,14 @@ class TestMakeHistogramPlot(BaseTestMakePlot, TestCase):
     def test_histogram_array_with_nan(self):
         factory = self.plot_factory_klass(x_col_name="b", x_arr=TEST_DF["b"],
                                           **self.hist_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
 
     def test_make_histgram_no_style(self):
         factory = self.plot_factory_klass(x_col_name="b", x_arr=TEST_DF["b"])
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
 
     def test_make_histogram_from_style_object(self):
@@ -163,7 +166,8 @@ class TestMakeHistogramPlot(BaseTestMakePlot, TestCase):
 
         factory = self.plot_factory_klass(x_col_name="b", x_arr=TEST_DF["b"],
                                           plot_style=style)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
 
     # Helpers -----------------------------------------------------------------
@@ -181,7 +185,8 @@ class BaseTestMakeXYPlot(BaseTestMakePlot):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=TEST_DF["a"],
                                           y_col_name="c", y_arr=TEST_DF["c"],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
 
     def test_plot_fail_no_y(self):
@@ -198,14 +203,16 @@ class BaseTestMakeXYPlot(BaseTestMakePlot):
         factory = self.plot_factory_klass(x_col_name="b", x_arr=TEST_DF["b"],
                                           y_col_name="c", y_arr=TEST_DF["c"],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
 
     def test_plot_array_with_nan_along_y(self):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=TEST_DF["a"],
                                           y_col_name="b", y_arr=TEST_DF["b"],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
 
     def test_with_str_color_dimension(self):
@@ -216,7 +223,8 @@ class BaseTestMakeXYPlot(BaseTestMakePlot):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=x_arr,
                                           y_col_name="b", y_arr=y_arr,
                                           z_col_name="d", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         d_values = TEST_DF["d"].unique()
         self.assert_valid_plot(plot, desc, num_renderers=len(d_values))
         self.assert_renderers_have_distinct_colors(plot)
@@ -229,7 +237,8 @@ class BaseTestMakeXYPlot(BaseTestMakePlot):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=x_arr,
                                           y_col_name="b", y_arr=y_arr,
                                           z_col_name="h", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         h_values = TEST_DF["h"].unique()
         self.assert_valid_plot(plot, desc, num_renderers=len(h_values))
 
@@ -242,7 +251,8 @@ class BaseTestMakeXYPlot(BaseTestMakePlot):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=x_arr,
                                           y_col_name="b", y_arr=y_arr,
                                           z_col_name="c", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         c_values = TEST_DF["c"].unique()
         self.assert_valid_plot(plot, desc, num_renderers=len(c_values))
         self.assert_renderers_have_distinct_colors(plot)
@@ -256,8 +266,8 @@ class BaseTestMakeXYPlot(BaseTestMakePlot):
         else:
             color_attr = 'color'
 
-        color_list = [getattr(plot.plots[name][0], color_attr)
-                      for name in plot.plots]
+        color_list = [getattr(renderer, color_attr)
+                      for renderer in plot.components]
         self.assertEqual(len(color_list), len(set(color_list)))
 
     def compute_x_y_arrays_split_by(self, x_col, y_col, z_col):
@@ -354,7 +364,8 @@ class TestMakeLinePlot(BaseTestMakeXYPlot, TestCase):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=x_arr,
                                           y_col_name="b", y_arr=y_arr,
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc, num_renderers=len(renderer_styles))
         self.assert_renderers_have_distinct_colors(plot)
 
@@ -369,7 +380,8 @@ class TestMakeLinePlot(BaseTestMakeXYPlot, TestCase):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=x_arr,
                                           y_col_name="b", y_arr=y_arr,
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc, num_renderers=len(renderer_styles))
         self.assert_renderers_have_distinct_colors(plot)
 
@@ -385,7 +397,8 @@ class TestMakeLinePlot(BaseTestMakeXYPlot, TestCase):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=x_arr,
                                           y_col_name="b", y_arr=y_arr,
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc, num_renderers=len(renderer_styles))
         self.assert_renderers_have_distinct_colors(plot)
 
@@ -424,11 +437,11 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
                                           y_col_name="a", y_arr=TEST_DF["a"],
                                           **self.plot_kw)
 
-        plot, desc = factory.generate_plot()
-
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
         # distance between x values is 1, so bar width is BAR_SQUEEZE_FACTOR
-        renderer = plot.plots['plot0'][0]
+        renderer = plot.components[0]
         self.assertEqual(renderer.bar_width, BAR_SQUEEZE_FACTOR)
 
     def test_unique_str_index_no_aggregation(self):
@@ -436,10 +449,11 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
                                           y_col_name="a", y_arr=TEST_DF["a"],
                                           **self.plot_kw)
 
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_valid_plot(plot, desc)
-        renderer = plot.plots['plot0'][0]
+        renderer = plot.components[0]
         assert_array_almost_equal(plot.data.arrays["e"],
                                   arange(len(TEST_DF["e"])))
         self.assertEqual(renderer.bar_width, 0.5)
@@ -454,7 +468,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
                                           y_col_name="a", y_arr=TEST_DF["a"][:1],  # noqa
                                           **self.plot_kw)
 
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
         for arr in plot.data.arrays:
             self.assertEqual(len(arr), 1)
@@ -464,7 +479,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
                                           y_col_name="a", y_arr=TEST_DF["a"],
                                           **self.plot_kw)
 
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_valid_plot(plot, desc)
         assert_array_almost_equal(plot.data.arrays["d"], arange(LEN))
@@ -477,7 +493,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
                                           y_col_name="a", y_arr=TEST_DF["a"],
                                           **self.plot_kw)
 
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_valid_plot(plot, desc)
         d_values = set(TEST_DF["d"])
@@ -492,7 +509,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
             **self.plot_kw
         )
 
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_valid_plot(plot, desc)
         # Index overwritten to be a list of ints:
@@ -506,7 +524,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
                                           y_col_name="a", y_arr=TEST_DF["a"],
                                           **self.plot_kw)
 
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_valid_plot(plot, desc)
         # Index overwritten to be a list of ints:
@@ -522,7 +541,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
                                           y_col_name="a", y_arr=TEST_DF["a"],
                                           **self.plot_kw)
 
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_valid_plot(plot, desc)
         # Index overwritten to be a list of ints:
@@ -543,7 +563,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
             y_arr=TEST_DF["a"], x_labels=[True, False], **self.plot_kw
         )
 
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_valid_plot(plot, desc)
         # Index overwritten to be a list of ints:
@@ -561,7 +582,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="e", x_arr=TEST_DF["e"],
                                           y_col_name="a", y_arr=TEST_DF["a"],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
 
         # Make sure all e values are presenting along the index axis
@@ -580,7 +602,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="d", x_arr=TEST_DF["d"],
                                           y_col_name="c", y_arr=TEST_DF["c"],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
         self.assert_bar_height_averaged(plot)
 
@@ -590,7 +613,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
                                           y_col_name="c", y_arr=TEST_DF["c"],
                                           x_labels=list("edcba"),
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
         self.assert_bar_height_averaged(plot, reverse_order=True)
 
@@ -601,16 +625,17 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="d", x_arr=TEST_DF["d"],
                                           y_col_name="c", y_arr=TEST_DF["c"],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         num_bars = len(TEST_DF["d"].unique())
         self.assert_valid_plot(plot, desc, num_renderers=1+num_bars,
-                               main_renderer="plot0")
+                               factory=factory, renderer_name="plot0")
         self.assert_bar_height_averaged(plot)
         # Make sure the error bar renderers are there too:
         for i in range(len(TEST_DF["d"].unique())):
             key = "plot{}".format(i+1)
-            self.assertIn(key, plot.plots)
-            self.assertIsInstance(plot.plots[key][0], LinePlot)
+            self.assertIn(key, factory.renderers)
+            self.assertIsInstance(factory.renderers[key], LinePlot)
 
     def test_colors_from_str_int_index_no_aggregation(self):
         x_arr, y_arr = self.compute_x_y_arrays_split_by("b2", "c", "j")
@@ -621,7 +646,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="b2", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="j", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         j_values = set(TEST_DF["j"])
         self.assert_valid_plot(plot, desc, num_renderers=len(j_values))
@@ -639,7 +665,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="k", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="i", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         hue_values = set(TEST_DF["i"])
         self.assert_valid_plot(plot, desc, num_renderers=len(hue_values))
@@ -661,7 +688,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="l", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="j", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         j_values = set(TEST_DF["j"])
         self.assert_valid_plot(plot, desc, num_renderers=len(j_values))
@@ -687,7 +715,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="d", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="i", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         i_values = set(TEST_DF["i"])
         d_values = set(TEST_DF["d"])
         self.assert_valid_plot(plot, desc, num_renderers=len(i_values))
@@ -712,7 +741,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="l", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="i", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         hue_values = set(TEST_DF["i"])
         x_values = set(TEST_DF["l"])
         # 1 for the bars, and len(x_values) for the error bars:
@@ -727,7 +757,7 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         self.assertEqual(labels, sorted(x_values))
 
         num_error_bars = len(hue_values) * len(x_values)
-        self.assert_error_bars_present(plot, num_error_bars)
+        self.assert_error_bars_present(factory, num_error_bars)
 
     def test_colors_from_bool_str_index_with_aggregation_and_error_bars(self):
         self.style.data_duplicate = "mean"
@@ -742,7 +772,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="l", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="h", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         hue_values = set(TEST_DF["h"])
         x_values = set(TEST_DF["l"])
         # 1 for the bars, and len(x_values) for the error bars:
@@ -758,7 +789,7 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         self.assertEqual(labels, sorted(x_values))
 
         num_error_bars = len(hue_values) * len(x_values)
-        self.assert_error_bars_present(plot, num_error_bars)
+        self.assert_error_bars_present(factory, num_error_bars)
 
     def test_colors_from_str_bool_index_with_aggregation_and_error_bars(self):
         self.style.data_duplicate = "mean"
@@ -773,7 +804,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="h", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="i", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         hue_values = set(TEST_DF["i"])
         x_values = set(TEST_DF["h"])
         # 1 for the bars, and len(x_values) for the error bars:
@@ -788,7 +820,7 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         self.assertEqual(labels, sorted([str(x) for x in x_values]))
 
         num_error_bars = len(hue_values) * len(x_values)
-        self.assert_error_bars_present(plot, num_error_bars)
+        self.assert_error_bars_present(factory, num_error_bars)
 
     def test_colors_from_bool_str_index_no_aggregation(self):
         x_arr, y_arr = self.compute_x_y_arrays_split_by("k", "c", "h")
@@ -799,7 +831,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="k", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="h", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc, num_renderers=2)
 
         assert_array_almost_equal(plot.data.arrays["kFalse"], arange(8))
@@ -819,7 +852,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="d", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="h", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         i_values = set(TEST_DF["i"])
         d_values = set(TEST_DF["d"])
@@ -844,7 +878,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="h", x_arr=x_arr,
                                           y_col_name="c", y_arr=y_arr,
                                           z_col_name="i", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc, num_renderers=2)
 
         # Index overwritten to be a list of ints:
@@ -871,7 +906,8 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
                                           z_col_name="i",
                                           x_labels=[True, False],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc, num_renderers=2)
 
         # Index overwritten to be a list of ints:
@@ -895,10 +931,11 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="e", x_arr=TEST_DF["e"],
                                           y_col_name="a", y_arr=TEST_DF["a"],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
-        self.force_plot_rendering(plot)
         self.assertIsInstance(plot.x_axis.tick_generator, DefaultTickGenerator)
+        self.force_plot_rendering(plot)
         # Ticks are decimated: every other label isn't displayed:
         self.assertEqual(set(plot.x_axis._tick_label_list),
                          set(TEST_DF["e"][::2]))
@@ -911,10 +948,11 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         factory = self.plot_factory_klass(x_col_name="e", x_arr=TEST_DF["e"],
                                           y_col_name="a", y_arr=TEST_DF["a"],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc)
-        self.force_plot_rendering(plot)
         self.assertIsInstance(plot.x_axis.tick_generator, ShowAllTickGenerator)
+        self.force_plot_rendering(plot)
         self.assertEqual(set(plot.x_axis._tick_label_list), set(TEST_DF["e"]))
 
     # utilities ---------------------------------------------------------------
@@ -926,25 +964,26 @@ class TestMakeBarPlot(BaseTestMakeXYPlot, TestCase, UnittestTools):
         height = plot.outer_height
         gc = PlotGraphicsContext((width, height), dpi=72)
         gc.render_component(plot)
+        return gc
 
     def assert_x_axis_labels_equal(self, plot, expected):
         with temp_bringup_ui_for(wrap_chaco_plot(plot)):
             self.assertEqual(plot.x_axis.labels, expected)
 
-    def assert_error_bars_present(self, plot, num_error_bars):
+    def assert_error_bars_present(self, factory, num_error_bars):
 
         for i in range(num_error_bars):
             key = "plot{}".format(i)
-            self.assertIn(key, plot.plots)
-            self.assertIsInstance(plot.plots[key][0], LinePlot)
-            if plot.legend:
+            self.assertIn(key, factory.renderers)
+            self.assertIsInstance(factory.renderers[key], LinePlot)
+            if factory.legend:
                 # Make sure the error bars are not present in the legend:
-                self.assertNotIn(key, plot.legend.labels)
+                self.assertNotIn(key, factory.legend.labels)
 
-        error_bar_x_data = [x for x in plot.data.arrays
+        error_bar_x_data = [x for x in factory.plot.data.arrays
                             if x.startswith(ERROR_BAR_DATA_KEY_PREFIX) and
                             x.endswith("_x")]
-        error_bar_y_data = [x for x in plot.data.arrays
+        error_bar_y_data = [x for x in factory.plot.data.arrays
                             if x.startswith(ERROR_BAR_DATA_KEY_PREFIX) and
                             x.endswith("_y")]
         self.assertEqual(len(error_bar_x_data), num_error_bars)
@@ -986,6 +1025,7 @@ class TestMakeHeatmapPlot(BaseTestMakePlot, TestCase):
         self.config_class = HeatmapPlotConfigurator
         config = self.config_class(data_source=TEST_DF)
         self.style = config.plot_style
+        self.style.container_style.include_colorbar = True
         self.plot_kw = {'plot_title': 'Plot 1', 'x_axis_title': 'foo',
                         'plot_style': self.style}
 
@@ -998,7 +1038,8 @@ class TestMakeHeatmapPlot(BaseTestMakePlot, TestCase):
                                           y_col_name="b2", y_arr=y_arr,
                                           z_col_name="c", z_arr=z_arr,
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc, with_contours=False)
 
     def test_create_with_interpolation(self):
@@ -1010,7 +1051,8 @@ class TestMakeHeatmapPlot(BaseTestMakePlot, TestCase):
                                           y_col_name="b2", y_arr=y_arr,
                                           z_col_name="c", z_arr=z_arr,
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc, with_contours=False)
 
     def test_create_with_contour(self):
@@ -1021,7 +1063,8 @@ class TestMakeHeatmapPlot(BaseTestMakePlot, TestCase):
                                           y_col_name="b2", y_arr=y_arr,
                                           z_col_name="c", z_arr=z_arr,
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_valid_plot(plot, desc, with_contours=True)
 
     # Helpers -----------------------------------------------------------------
@@ -1034,32 +1077,31 @@ class TestMakeHeatmapPlot(BaseTestMakePlot, TestCase):
                                     values=z_col_name).values
         return x_arr, y_arr, z_arr
 
-    def assert_valid_plot(self, plot, desc, with_contours=False):
-        """ Overridden since plot container generated instead of Plot.
+    def assert_valid_plot(self, container, desc, with_contours=False):
+        """ Overridden since container plot generated instead of Plot.
         """
-        self.assertIsInstance(plot, HPlotContainer)
+        self.assertIsInstance(container, HPlotContainer)
         self.assertIsInstance(desc, dict)
-        self.assertIs(desc["plot"], plot)
+        self.assertIs(desc["plot"], container)
         self.assertEqual(desc["plot_type"], self.type)
         self.assertTrue(desc['visible'])
 
-        # 2 plot areas in the container
-        self.assertEqual(len(plot.plot_components), 2)
+        # 2 container areas in the container
+        self.assertEqual(len(container.components), 2)
 
-        main_plot = plot.plot_components[0]
-        self.assertIsInstance(main_plot, Plot)
-        self.assertIsInstance(plot.plot_components[1], ColorBar)
+        main_plot = container.components[0]
+        self.assertIsInstance(main_plot, OverlayPlotContainer)
+        self.assertIsInstance(container.components[1], ColorBar)
 
-        # Normally only the image plot in the main plot, except if contours are
-        # turned on:
+        # Normally only the image container in the main container, except if
+        # contours are turned on:
         if with_contours:
             num_renderers = 2
         else:
             num_renderers = 1
 
-        self.assertEqual(len(main_plot.plots), num_renderers)
-        self.assertIsInstance(main_plot.plots["plot0"][0],
-                              self.renderer_class)
+        self.assertEqual(len(main_plot.components), num_renderers)
+        self.assertIsInstance(main_plot.components[0], self.renderer_class)
         if with_contours:
             self.assertIsInstance(main_plot.plots["plot1"][0], ContourLinePlot)
 
@@ -1086,12 +1128,16 @@ class BaseScatterPlotTools(object):
 
     def assert_no_tools(self, plot):
         self.assertEqual(plot.tools, [])
-        self.assertEqual(plot.legend.tools, [])
-        # Legend and title:
-        self.assertEqual(len(plot.overlays), 2)
-        for renderers in plot.plots.values():
-            for renderer in renderers:
-                self.assertEqual(renderer.tools, [])
+        if hasattr(plot, "legend"):
+            self.assertFalse(plot.legend.tools, [])
+            # Legend and title:
+            self.assertEqual(len(plot.overlays), 2)
+        else:
+            self.assertEqual(len(plot.overlays), 1)
+
+        for renderer in plot.components:
+            self.assertIsInstance(renderer.tools[0], BroadcasterTool)
+            self.assertEqual(renderer.tools[0].tools, [])
 
     def assert_zoom_pan_tools_present(self, factory=None, plot=None):
         if factory is None:
@@ -1101,30 +1147,35 @@ class BaseScatterPlotTools(object):
             plot = self.plot
 
         self.assertIn("pan", factory.plot_tools)
-        self.assertGreaterEqual(len(plot.tools), 1)
-        self.assertIsInstance(plot.tools[0], PanTool)
-
         self.assertIn("zoom", factory.plot_tools)
-        klasses = {o.__class__.__name__ for o in plot.overlays}
-        self.assertIn("BetterSelectingZoom", klasses)
 
-    def assert_legend_with_tool(self, factory=None, plot=None,
-                                color_values=None):
+        first_renderer = plot.components[0]
+        # tools added to renderers via the broadcaster tool:
+        self.assertGreaterEqual(len(first_renderer.tools), 1)
+        broadcaster_tool = first_renderer.tools[0]
+        self.assertIsInstance(broadcaster_tool, BroadcasterTool)
+
+        num_renderers = len(plot.components)
+        pan_tools = [tool for tool in broadcaster_tool.tools
+                     if isinstance(tool, PanTool)]
+        zoom_tools = [tool for tool in broadcaster_tool.tools
+                      if isinstance(tool, BetterSelectingZoom)]
+        self.assertEqual(len(pan_tools), num_renderers)
+        self.assertEqual(len(zoom_tools), num_renderers)
+
+    def assert_legend_with_tool(self, factory=None):
         if factory is None:
             factory = self.factory
 
-        if plot is None:
-            plot = self.plot
-
-        if color_values is None:
-            color_values = TEST_DF["d"]
-
         self.assertIn("legend", factory.plot_tools)
-        self.assertTrue(plot.legend.visible)
-        self.assertEqual(set(plot.legend.plots.keys()), set(color_values))
-        self.assertEqual(len(plot.legend.tools), 2)
-        self.assertIsInstance(plot.legend.tools[0], LegendTool)
-        self.assertIsInstance(plot.legend.tools[1], LegendHighlighter)
+        legend = factory.legend
+        self.assertIsNotNone(legend)
+        self.assertTrue(legend.visible)
+        color_values = TEST_DF["d"]
+        self.assertEqual(set(legend.plots.keys()), set(color_values))
+        self.assertEqual(len(legend.tools), 2)
+        self.assertIsInstance(legend.tools[0], LegendTool)
+        self.assertIsInstance(legend.tools[1], LegendHighlighter)
 
     def assert_click_selector_present(self, factory=None, plot=None):
         if factory is None:
@@ -1135,12 +1186,10 @@ class BaseScatterPlotTools(object):
 
         self.assertIn("click_selector", factory.plot_tools)
 
-        for name, renderers in plot.plots.items():
-            renderer = renderers[0]
-            self.assertEqual(len(renderer.tools), 1)
-            # It's a DataFrameInspector because it can then drive both click
-            # and hover events/tools:
-            self.assertIsInstance(renderer.tools[0], DataframeScatterInspector)
+        for renderer in plot.components:
+            # Broadcaster tool also there for first renderer:
+            tool_types = [tool.__class__.__name__ for tool in renderer.tools]
+            self.assertIn("DataframeScatterInspector", tool_types)
             self.assertGreaterEqual(len(renderer.overlays), 1)
             self.assertIsInstance(renderer.overlays[0],
                                   ScatterInspectorOverlay)
@@ -1151,10 +1200,16 @@ class BaseScatterPlotTools(object):
         self.assertIn("DataframeScatterOverlay", klasses)
 
         overlay_inspectors = set(plot.overlays[-1].inspectors)
-        for name, renderer in plot.plots.items():
-            renderer = renderer[0]
-            self.assertEqual(len(renderer.tools), 1)
-            inspector = renderer.tools[0]
+        for i, renderer in enumerate(plot.components):
+            # In addition to the inspector tool, there is the broadcaster for
+            # zooming/panning for the first renderer:
+            if i == 0:
+                self.assertEqual(len(renderer.tools), 2)
+                inspector = renderer.tools[1]
+            else:
+                self.assertEqual(len(renderer.tools), 1)
+                inspector = renderer.tools[0]
+
             self.assertIsInstance(inspector, DataframeScatterInspector)
             self.assertIn(inspector, overlay_inspectors)
 
@@ -1174,15 +1229,16 @@ class TestScatterPlotTools(TestCase, BaseScatterPlotTools):
             x_col_name="a", x_arr=TEST_DF["a"].values,
             y_col_name="c", y_arr=TEST_DF["c"].values, **self.plot_kw
         )
-        self.plot, desc = self.factory.generate_plot()
+        desc = self.factory.generate_plot()
+        self.plot = desc["plot"]
 
     def test_tools_present_default(self):
         """ By default, zoom, pan, click selector and legend tools.
         """
         self.assert_zoom_pan_tools_present()
         self.assert_click_selector_present()
-        # No legend tool per se since only 1 renderer
-        self.assertFalse(self.plot.legend.visible)
+        # No legend since only 1 renderer
+        self.assertIsNone(self.factory.legend)
 
         self.assertIn("hover", self.factory.plot_tools)
         # But by default, no hover columns so no overlay:
@@ -1194,7 +1250,8 @@ class TestScatterPlotTools(TestCase, BaseScatterPlotTools):
             y_col_name="c", y_arr=TEST_DF["c"].values,
             hover_col_names=["a"], **self.plot_kw
         )
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_hover_tool_present(factory, plot)
 
     def test_request_no_tools_present(self):
@@ -1203,7 +1260,8 @@ class TestScatterPlotTools(TestCase, BaseScatterPlotTools):
             y_col_name="c", y_arr=TEST_DF["c"].values, plot_tools=set(),
             **self.plot_kw
         )
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_no_tools(plot)
 
     def test_request_no_inspector_tools_present_basic_scatter(self):
@@ -1212,15 +1270,15 @@ class TestScatterPlotTools(TestCase, BaseScatterPlotTools):
             y_col_name="c", y_arr=TEST_DF["c"].values,
             plot_tools={"pan", "zoom"}, **self.plot_kw
         )
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
         self.assert_zoom_pan_tools_present()
-        # Pan is a tool
-        self.assertEqual(len(plot.tools), 1)
-        # Zoom is an overlay, just like the plot title and legend
-        self.assertEqual(len(plot.overlays), 3)
-        for renderers in plot.plots.values():
-            for renderer in renderers:
-                self.assertEqual(renderer.tools, [])
+        renderer = plot.components[0]
+        # Just the broadcaster tool:
+        self.assertEqual(len(renderer.tools), 1)
+        self.assertIsInstance(renderer.tools[0], BroadcasterTool)
+        # Just a title overlay:
+        self.assertEqual(len(plot.overlays), 1)
 
     def test_tools_present_colored_scatter_by_str(self):
         """ Tools present on scatter when color dimension specified.
@@ -1231,10 +1289,11 @@ class TestScatterPlotTools(TestCase, BaseScatterPlotTools):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=all_x_arr,
                                           y_col_name="b", y_arr=all_y_arr,
                                           z_col_name="d", **self.plot_kw)
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_zoom_pan_tools_present()
-        self.assert_legend_with_tool(factory, plot)
+        self.assert_legend_with_tool(factory)
         self.assert_click_selector_present(factory, plot)
 
     def test_tools_present_colored_scatter_by_str_and_hover(self):
@@ -1247,10 +1306,11 @@ class TestScatterPlotTools(TestCase, BaseScatterPlotTools):
             x_col_name="a", x_arr=all_x_arr, y_col_name="b", y_arr=all_y_arr,
             z_col_name="d", hover_col_names=["a", "b", "d"], **self.plot_kw
         )
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_zoom_pan_tools_present(factory, plot)
-        self.assert_legend_with_tool(factory, plot)
+        self.assert_legend_with_tool(factory)
         self.assert_click_selector_present(factory, plot)
         self.assert_hover_tool_present(factory, plot)
 
@@ -1266,7 +1326,8 @@ class TestScatterPlotTools(TestCase, BaseScatterPlotTools):
             x_col_name="a", x_arr=all_x_arr, y_col_name="b", y_arr=all_y_arr,
             z_col_name="d", hover_col_names=["a", "b", "d"], **self.plot_kw
         )
-        plot, desc = factory.generate_plot()
+        desc = factory.generate_plot()
+        plot = desc["plot"]
 
         self.assert_zoom_pan_tools_present(factory, plot)
         self.assert_click_selector_present(factory, plot)
@@ -1276,7 +1337,7 @@ class TestScatterPlotTools(TestCase, BaseScatterPlotTools):
         # Default marker is a circle of size 6:
         self.assertEqual(self.style.renderer_styles[0].marker, "circle")
         self.assertEqual(self.style.renderer_styles[0].marker_size, 6)
-        renderer = list(self.plot.plots.values())[0][0]
+        renderer = self.plot.components[0]
         inspector_overlay = renderer.overlays[0]
         self.assertEqual(inspector_overlay.selection_marker, "circle")
         self.assertEqual(inspector_overlay.selection_marker_size, 6)
@@ -1288,8 +1349,9 @@ class TestScatterPlotTools(TestCase, BaseScatterPlotTools):
         factory = self.plot_factory_klass(x_col_name="a", x_arr=TEST_DF["a"],
                                           y_col_name="c", y_arr=TEST_DF["c"],
                                           **self.plot_kw)
-        plot, desc = factory.generate_plot()
-        renderer = list(plot.plots.values())[0][0]
+        desc = factory.generate_plot()
+        plot = desc["plot"]
+        renderer = plot.components[0]
         inspector_overlay = renderer.overlays[0]
         self.assertEqual(inspector_overlay.selection_marker, "square")
         self.assertEqual(inspector_overlay.selection_marker_size, 9)
@@ -1311,7 +1373,8 @@ class TestCmapScatterPlotTools(TestCase, BaseScatterPlotTools):
             y_col_name="c", y_arr=TEST_DF["c"],
             z_col_name="b", z_arr=TEST_DF["b"], **self.plot_kw
         )
-        self.container, desc = self.factory.generate_plot()
+        desc = self.factory.generate_plot()
+        self.container = desc["plot"]
 
     def test_tools_present_colored_scatter_by_float(self):
         """ Tools present when building a scatter plot colored by float column.
@@ -1328,7 +1391,8 @@ class TestCmapScatterPlotTools(TestCase, BaseScatterPlotTools):
         """
         factory = self.factory
         factory.hover_col_names = ["a", "b"]
-        container, desc = self.factory.generate_plot()
+        desc = self.factory.generate_plot()
+        container = desc["plot"]
         plot = container.plot_components[0]
 
         self.assert_zoom_pan_tools_present(factory, plot)

--- a/pybleau/app/plotting/tests/test_plot_styles.py
+++ b/pybleau/app/plotting/tests/test_plot_styles.py
@@ -148,7 +148,8 @@ class TestPlotStyleBehaviors(TestCase):
         self.assertEqual(style.y_axis_style.auto_range_high, 4.1)
 
         # Initialize rounding numbers at the integer level:
-        style.initialize_axis_ranges(plot, transform=0)
+        style.range_transform = lambda x: int(x)
+        style.initialize_axis_ranges(plot)
 
         self.assertEqual(style.x_axis_style.range_low, 1)
         self.assertEqual(style.x_axis_style.range_high, 2)

--- a/pybleau/app/ui/dataframe_plot_manager_view.py
+++ b/pybleau/app/ui/dataframe_plot_manager_view.py
@@ -94,7 +94,7 @@ class DataFramePlotManagerView(ModelView):
                          enabled_when="len(model.contained_plots) > 0"),
                 ),
             ),
-            resizable=True, width=800, scrollable=True
+            resizable=True, width=800, scrollable=True, height=1000
         )
         return view
 

--- a/scripts/explore_dataframe_with_plots.py
+++ b/scripts/explore_dataframe_with_plots.py
@@ -16,11 +16,13 @@ from pybleau.app.plotting.multi_plot_config import MultiLinePlotConfigurator
 
 initialize_logging(logging_level="DEBUG")
 
+col4 = np.random.randn(8)
+
 TEST_DF = DataFrame({"Col_1": [1, 2, 3, 4, 5, 6, 7, 8],
                      "Col_2": 5*np.array([1, 2, 3, 4, 5, 6, 7, 8])[::-1],
                      "Col_3": ["aa_aaa", "bb_bbb", "aa_aaa", "cc_ccc",
                                "ee_eee", "dd_ddd", "ff_fff", "gg_ggg"],
-                     "Col_4": np.random.randn(8),
+                     "Col_4": col4,
                      })
 
 config = HistogramPlotConfigurator(data_source=TEST_DF)
@@ -83,7 +85,7 @@ plot_manager = DataFramePlotManager(
         cust_plot1,
         desc6,
         desc7,
-        # desc8
+        desc8
     ],
     data_source=TEST_DF, source_analyzer=analyzer
 )

--- a/scripts/explore_dataframe_with_plots.py
+++ b/scripts/explore_dataframe_with_plots.py
@@ -1,4 +1,6 @@
-
+""" Illustrates how to programmatically create a DF analyzer with populated
+plots in the plotter tool.
+"""
 from pandas import DataFrame
 import numpy as np
 from chaco.api import Plot, ArrayPlotData
@@ -10,11 +12,12 @@ from pybleau.app.api import DataFrameAnalyzer, DataFrameAnalyzerView, \
 from pybleau.app.model.plot_descriptor import PlotDescriptor
 from pybleau.app.plotting.api import BarPlotConfigurator, \
     HistogramPlotConfigurator, LinePlotConfigurator, ScatterPlotConfigurator
+from pybleau.app.plotting.multi_plot_config import MultiLinePlotConfigurator
 
 initialize_logging(logging_level="DEBUG")
 
 TEST_DF = DataFrame({"Col_1": [1, 2, 3, 4, 5, 6, 7, 8],
-                     "Col_2": np.array([1, 2, 3, 4, 5, 6, 7, 8])[::-1],
+                     "Col_2": 5*np.array([1, 2, 3, 4, 5, 6, 7, 8])[::-1],
                      "Col_3": ["aa_aaa", "bb_bbb", "aa_aaa", "cc_ccc",
                                "ee_eee", "dd_ddd", "ff_fff", "gg_ggg"],
                      "Col_4": np.random.randn(8),
@@ -22,34 +25,27 @@ TEST_DF = DataFrame({"Col_1": [1, 2, 3, 4, 5, 6, 7, 8],
 
 config = HistogramPlotConfigurator(data_source=TEST_DF)
 config.x_col_name = "Col_4"
-desc = PlotDescriptor(x_col_name="Col_4", plot_config=config,
-                      plot_title="Plot 1")
 
 config2 = BarPlotConfigurator(data_source=TEST_DF)
 config2.x_col_name = "Col_1"
 config2.y_col_name = "Col_2"
-desc2 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
-                       plot_config=config2, plot_title="Plot 2")
+desc2 = PlotDescriptor(plot_config=config2, plot_title="Plot 2")
 
 config3 = ScatterPlotConfigurator(data_source=TEST_DF)
 config3.x_col_name = "Col_1"
 config3.y_col_name = "Col_2"
-desc3 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
-                       plot_config=config3, plot_title="Plot 3")
+desc3 = PlotDescriptor(plot_config=config3, plot_title="Plot 3")
 
 config4 = ScatterPlotConfigurator(data_source=TEST_DF)
 config4.x_col_name = "Col_1"
 config4.y_col_name = "Col_2"
 config4.z_col_name = "Col_3"
-desc4 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
-                       z_col_name="Col_3",
-                       plot_config=config4, plot_title="Plot 4")
+desc4 = PlotDescriptor(plot_config=config4, plot_title="Plot 4")
 
 config5 = LinePlotConfigurator(data_source=TEST_DF)
 config5.x_col_name = "Col_1"
 config5.y_col_name = "Col_2"
-desc5 = PlotDescriptor(x_col_name="Col_1", y_col_name="Col_2",
-                       plot_config=config5, plot_title="Plot 5")
+desc5 = PlotDescriptor(plot_config=config5, plot_title="Plot 5")
 
 cust_plot1 = Plot(ArrayPlotData(x=[1, 2, 3], y=[1, 2, 3]))
 cust_plot1.plot(("x", "y"))
@@ -60,13 +56,35 @@ cust_plot1.y_axis.title = "y"
 config6 = BarPlotConfigurator(data_source=TEST_DF)
 config6.x_col_name = "Col_3"
 config6.y_col_name = "Col_1"
-desc6 = PlotDescriptor(x_col_name="Col_3", y_col_name="Col_1",
-                       plot_config=config6, plot_title="Plot 6")
+desc6 = PlotDescriptor(plot_config=config6, plot_title="Plot 6")
+
+config7 = MultiLinePlotConfigurator(data_source=TEST_DF)
+config7.x_col_name = "Col_1"
+config7.y_col_names = ["Col_1", "Col_2", "Col_4"]
+desc7 = PlotDescriptor(plot_config=config7, plot_title="Plot 7",
+                       container_idx=1)
+
+config8 = ScatterPlotConfigurator(data_source=TEST_DF)
+config8.x_col_name = "Col_1"
+config8.y_col_name = "Col_2"
+config8.z_col_name = "Col_4"
+desc8 = PlotDescriptor(plot_config=config8, plot_title="Plot 8",
+                       container_idx=1)
 
 analyzer = DataFrameAnalyzer(source_df=TEST_DF)
 
 plot_manager = DataFramePlotManager(
-    contained_plots=[desc, desc2, desc3, desc4, desc5, cust_plot1, desc6],
+    contained_plots=[
+        config,
+        desc2,
+        desc3,
+        desc4,
+        desc5,
+        cust_plot1,
+        desc6,
+        desc7,
+        # desc8
+    ],
     data_source=TEST_DF, source_analyzer=analyzer
 )
 


### PR DESCRIPTION
* Move implementation of all factories from `Plot` to `OverlayPlotContainer`.
* Add renderer styling so plot styling can offer a lot more granular control over styling including color
* Supports moving XY plots from the left y-axis to a secondary one on the right.
* Global code improvements to increase code reuse, remove dead attributes, ...

Requires `app_common` version `0.13.0` or above.