### PR TITLE
Maint: legacy descriptor serializer

### DIFF
--- a/pybleau/app/io/deserializer.py
+++ b/pybleau/app/io/deserializer.py
@@ -30,7 +30,7 @@ class dataFramePlotManagerDeSerializer(dataElementDeSerializer):
 
 class plotDescriptorDeSerializer(dataElementDeSerializer):
 
-    protocol_version = 2
+    protocol_version = 1
 
     def _klass_default(self):
         from pybleau.app.model.plot_descriptor import PlotDescriptor
@@ -41,12 +41,6 @@ class scatterPlotConfiguratorDeSerializer(dataElementDeSerializer):
     def _klass_default(self):
         from pybleau.app.plotting.plot_config import ScatterPlotConfigurator
         return ScatterPlotConfigurator
-
-
-class singlescatterPlotStyleDeSerializer(dataElementDeSerializer):
-    def _klass_default(self):
-        from pybleau.app.plotting.plot_style import SingleScatterPlotStyle
-        return SingleScatterPlotStyle
 
 
 class linePlotConfiguratorDeSerializer(dataElementDeSerializer):
@@ -147,9 +141,15 @@ class axisStyleDeSerializer(dataElementDeSerializer):
         return AxisStyle
 
 
+class baseXYPlotStyleDeSerializer(dataElementDeSerializer):
+    def _klass_default(self):
+        from pybleau.app.plotting.plot_style import BaseXYPlotStyle
+        return BaseXYPlotStyle
+
+
 class baseColorXYPlotStyleDeSerializer(dataElementDeSerializer):
     def _klass_default(self):
-        from pybleau.app.plotting.bar_plot_style import BaseColorXYPlotStyle
+        from pybleau.app.plotting.plot_style import BaseColorXYPlotStyle
         return BaseColorXYPlotStyle
 
 

--- a/pybleau/app/io/legacy_deserializer.py
+++ b/pybleau/app/io/legacy_deserializer.py
@@ -1,4 +1,9 @@
 
+from .deserializer import singleLinePlotStyleDeSerializer, \
+    singleScatterPlotStyleDeSerializer, plotDescriptorDeSerializer
+from ..plotting.plot_config import DEFAULT_CONFIGS, DEFAULT_STYLES
+
+
 class plotDescriptorDeSerializer_v0(plotDescriptorDeSerializer):
 
     protocol_version = 0
@@ -25,13 +30,23 @@ class plotDescriptorDeSerializer_v0(plotDescriptorDeSerializer):
         return instance
 
 
-class plotDescriptorDeSerializer_v1(plotDescriptorDeSerializer):
+class scatterPlotStyleDeSerializer(singleScatterPlotStyleDeSerializer):
+    """ Legacy class which was renamed.
+    """
+    protocol_version = 0
 
-    protocol_version = 1
 
-    def get_instance(self, constructor_data):
-        constructor_data['kwargs'].pop("ndim")
-        instance = super(plotDescriptorDeSerializer_v1, self).get_instance(
-            constructor_data
-        )
-        return instance
+class linePlotStyleDeSerializer(singleLinePlotStyleDeSerializer):
+    """ Legacy class which was renamed.
+    """
+    protocol_version = 0
+
+
+LEGACY_DESERIALIZER_MAP = {
+    "plotDescriptor": {
+        0: plotDescriptorDeSerializer_v0,
+    },
+    "scatterPlotStyle": {0: scatterPlotStyleDeSerializer},
+    "linePlotStyle": {0: linePlotStyleDeSerializer},
+}
+

--- a/pybleau/app/io/legacy_deserializer.py
+++ b/pybleau/app/io/legacy_deserializer.py
@@ -1,0 +1,37 @@
+
+class plotDescriptorDeSerializer_v0(plotDescriptorDeSerializer):
+
+    protocol_version = 0
+
+    def get_instance(self, constructor_data):
+        kwargs = constructor_data['kwargs']
+        # For a short amount of time, new plot_descriptors may have been stored
+        # with protocol version at 0 instead of 1, so check:
+        if "plot_config" not in kwargs and 'factory_kwargs' in kwargs:
+            factory_kw = constructor_data['kwargs'].pop('factory_kwargs')
+            # Convert factory kw to configurator kw:
+            for key in ["x_arr", "y_arr", "z_arr"]:
+                factory_kw.pop(key, None)
+
+            config_klass = DEFAULT_CONFIGS[kwargs['plot_type']]
+            style_klass = DEFAULT_STYLES[kwargs['plot_type']]
+            style_kw = factory_kw.pop('plot_style')
+            factory_kw['plot_style'] = style_klass(**style_kw)
+            kwargs["plot_config"] = config_klass(**factory_kw)
+
+        instance = super(plotDescriptorDeSerializer_v0, self).get_instance(
+            constructor_data
+        )
+        return instance
+
+
+class plotDescriptorDeSerializer_v1(plotDescriptorDeSerializer):
+
+    protocol_version = 1
+
+    def get_instance(self, constructor_data):
+        constructor_data['kwargs'].pop("ndim")
+        instance = super(plotDescriptorDeSerializer_v1, self).get_instance(
+            constructor_data
+        )
+        return instance

--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -44,7 +44,7 @@ class DataFramePlotManager_Serializer(DataElement_Serializer):
 
 class PlotDescriptor_Serializer(DataElement_Serializer):
 
-    protocol_version = 2
+    protocol_version = 1
 
     def get_instance_data(self, obj):
         data = super(PlotDescriptor_Serializer, self).get_instance_data(obj)


### PR DESCRIPTION
- Somehow, the removal of the `ndim` attribute of a PlotDescriptor in #33  didn't require a bump in the protocol version for the serializer/deserializer. This PR reverts that.
- Added a legacy deserializer module to be use to contribute to downstream projects serializing objects containing pybleau plot components.
- Add deserializer for the `BaseXYPlotStyle` since there is a serializer for it.