### PR TITLE
DFPlotter serialization: next_plot_id treated as the derived trait

### DIFF
--- a/pybleau/app/io/deserializer.py
+++ b/pybleau/app/io/deserializer.py
@@ -22,6 +22,9 @@ def deserialize(serial_data, array_collection=None):
 
 
 class dataFramePlotManagerDeSerializer(dataElementDeSerializer):
+
+    protocol_version = 1
+
     def _klass_default(self):
         from pybleau.app.model.dataframe_plot_manager import \
             DataFramePlotManager

--- a/pybleau/app/io/legacy_deserializer.py
+++ b/pybleau/app/io/legacy_deserializer.py
@@ -1,7 +1,17 @@
 
 from .deserializer import singleLinePlotStyleDeSerializer, \
-    singleScatterPlotStyleDeSerializer, plotDescriptorDeSerializer
+    singleScatterPlotStyleDeSerializer, plotDescriptorDeSerializer, \
+    dataFramePlotManagerDeSerializer
 from ..plotting.plot_config import DEFAULT_CONFIGS, DEFAULT_STYLES
+
+
+class dataFramePlotManagerDeSerializer_v0(dataFramePlotManagerDeSerializer):
+
+    protocol_version = 0
+
+    def get_instance(self, constructor_data):
+        kwargs = constructor_data['kwargs']
+        kwargs.pop("next_plot_id")
 
 
 class plotDescriptorDeSerializer_v0(plotDescriptorDeSerializer):
@@ -48,4 +58,5 @@ LEGACY_DESERIALIZER_MAP = {
     },
     "scatterPlotStyle": {0: scatterPlotStyleDeSerializer},
     "linePlotStyle": {0: linePlotStyleDeSerializer},
+    "dataFramePlotManager": {0: dataFramePlotManagerDeSerializer_v0}
 }

--- a/pybleau/app/io/legacy_deserializer.py
+++ b/pybleau/app/io/legacy_deserializer.py
@@ -12,6 +12,9 @@ class dataFramePlotManagerDeSerializer_v0(dataFramePlotManagerDeSerializer):
     def get_instance(self, constructor_data):
         kwargs = constructor_data['kwargs']
         kwargs.pop("next_plot_id")
+        return super(dataFramePlotManagerDeSerializer_v0, self).get_instance(
+            constructor_data
+        )
 
 
 class plotDescriptorDeSerializer_v0(plotDescriptorDeSerializer):

--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -37,9 +37,11 @@ def serialize(obj, array_collection=None):
 
 
 class DataFramePlotManager_Serializer(DataElement_Serializer):
+
+    protocol_version = 1
+
     def attr_names_to_serialize(self, obj):
-        return ['name', 'uuid', "source_analyzer_id", "contained_plots",
-                "next_plot_id"]
+        return ['name', 'uuid', "source_analyzer_id", "contained_plots"]
 
 
 class PlotDescriptor_Serializer(DataElement_Serializer):


### PR DESCRIPTION
Update DFPlotter protocole to 1 and remove `next_plot_id` from list of serialized traits.