### PR TITLE
Fix old style serialization

### DIFF
--- a/pybleau/app/io/deserializer.py
+++ b/pybleau/app/io/deserializer.py
@@ -61,6 +61,9 @@ class plotDescriptorDeSerializer(dataElementDeSerializer):
 
 
 class scatterPlotConfiguratorDeSerializer(dataElementDeSerializer):
+
+    protocol_version = 1
+
     def _klass_default(self):
         from pybleau.app.plotting.plot_config import ScatterPlotConfigurator
         return ScatterPlotConfigurator
@@ -91,6 +94,9 @@ class barPlotConfiguratorDeSerializer(dataElementDeSerializer):
 
 
 class barPlotStyleDeSerializer(dataElementDeSerializer):
+
+    protocol_version = 1
+
     def _klass_default(self):
         from pybleau.app.plotting.bar_plot_style import BarPlotStyle
         return BarPlotStyle
@@ -103,6 +109,9 @@ class histogramPlotConfiguratorDeSerializer(dataElementDeSerializer):
 
 
 class histogramPlotStyleDeSerializer(dataElementDeSerializer):
+
+    protocol_version = 1
+
     def _klass_default(self):
         from pybleau.app.plotting.histogram_plot_style import \
             HistogramPlotStyle

--- a/pybleau/app/io/legacy_deserializer.py
+++ b/pybleau/app/io/legacy_deserializer.py
@@ -122,7 +122,7 @@ class scatterPlotConfiguratorDeSerializer_v0(scatterPlotConfiguratorDeSerializer
         x = super(scatterPlotConfiguratorDeSerializer_v0, self).get_instance(
             constructor_data
         )
-        if x.frozen:
+        if x.data_source is not None:
             x.update_style()
         return x
 

--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -95,7 +95,7 @@ class BaseSinglePlotConfigurator_Serializer(DataElement_Serializer):
 
 
 class ScatterPlotConfigurator_Serializer(BaseSinglePlotConfigurator_Serializer):  # noqa
-    pass
+    protocol_version = 1
 
 
 class LinePlotConfigurator_Serializer(BaseSinglePlotConfigurator_Serializer):
@@ -142,12 +142,18 @@ class SingleLinePlotStyle_Serializer(BaseXYPlotStyle_Serializer):
 
 
 class BarPlotStyle_Serializer(BaseColorXYPlotStyle_Serializer):
+
+    protocol_version = 1
+
     def attr_names_to_serialize(self, obj):
         attrs = super(BarPlotStyle_Serializer, self).attr_names_to_serialize(obj)  # noqa
         return attrs + ["bar_style", "data_duplicate", "show_error_bars"]
 
 
 class HistogramPlotStyle_Serializer(BaseXYPlotStyle_Serializer):
+
+    protocol_version = 1
+
     def attr_names_to_serialize(self, obj):
         attrs = super(HistogramPlotStyle_Serializer, self).attr_names_to_serialize(obj)  # noqa
         return attrs + ["num_bins", "bin_limits", "bar_width_factor"]


### PR DESCRIPTION
Styles were organized differently: bump protocol numbers and handle legacy deserialization so styling information is lost (ok with only end users) but avoid deserialization failure. 