### PR TITLE
Enh: robustify df analyzer sort col

### DIFF
--- a/pybleau/app/api.py
+++ b/pybleau/app/api.py
@@ -1,7 +1,6 @@
 from .ui.dataframe_analyzer_model_view import DataFrameAnalyzer, DataFrameAnalyzerView  # noqa
 from .model.dataframe_plot_manager import DataFramePlotManager  # noqa
-from .model.multi_dfs_dataframe_analyzer import MultiDataFrameAnalyzer
+from .model.multi_dfs_dataframe_analyzer import MultiDataFrameAnalyzer  # noqa
 from .ui.dataframe_plot_manager_view import DataFramePlotManagerView  # noqa
 from .tools.filter_expression_manager import FilterExpression, FilterExpressionManager  # noqa
 from .app.main import main  # noqa
-

--- a/pybleau/app/io/deserializer.py
+++ b/pybleau/app/io/deserializer.py
@@ -23,6 +23,8 @@ def deserialize(serial_data, array_collection=None):
 
 class dataFrameAnalyzerDeSerializer(dataElementDeSerializer):
 
+    protocol_version = 1
+
     def get_instance(self, constructor_data):
         instance = super(dataFrameAnalyzerDeSerializer, self).get_instance(
             constructor_data

--- a/pybleau/app/io/legacy_deserializer.py
+++ b/pybleau/app/io/legacy_deserializer.py
@@ -3,8 +3,18 @@ from traits.api import HasStrictTraits, Set
 from .deserializer import singleLinePlotStyleDeSerializer, \
     singleScatterPlotStyleDeSerializer, plotDescriptorDeSerializer, \
     dataFramePlotManagerDeSerializer, histogramPlotStyleDeSerializer, \
-    scatterPlotConfiguratorDeSerializer
+    scatterPlotConfiguratorDeSerializer, dataFrameAnalyzerDeSerializer
 from ..plotting.plot_config import DEFAULT_CONFIGS, DEFAULT_STYLES
+
+
+class dataFrameAnalyzerDeSerializer_v0(dataFrameAnalyzerDeSerializer):
+
+    protocol_version = 0
+
+    def get_instance(self, constructor_data):
+        constructor_data['kwargs'].pop('index_name')
+        return super(dataFrameAnalyzerDeSerializer_v0, self).get_instance(
+            constructor_data)
 
 
 class dataFramePlotManagerDeSerializer_v0(dataFramePlotManagerDeSerializer):
@@ -133,5 +143,6 @@ LEGACY_DESERIALIZER_MAP = {
     "linePlotStyle": {0: linePlotStyleDeSerializer},
     "dataFramePlotManager": {0: dataFramePlotManagerDeSerializer_v0},
     "histogramPlotStyle": {0: histogramPlotStyleDeSerializer_v0},
-    "scatterPlotConfigurator": {0: scatterPlotConfiguratorDeSerializer_v0}
+    "scatterPlotConfigurator": {0: scatterPlotConfiguratorDeSerializer_v0},
+    "dataFrameAnalyzer": {0: dataFrameAnalyzerDeSerializer_v0}
 }

--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -38,10 +38,12 @@ def serialize(obj, array_collection=None):
 
 class DataFrameAnalyzer_Serializer(DataElement_Serializer):
 
+    protocol_version = 1
+
     def attr_names_to_serialize(self, obj):
         return ['name', 'uuid', 'source_df', 'filter_exp', 'summary_index',
                 'sort_by_col', 'data_selected', 'num_displayed_rows',
-                'index_name', "plot_manager_list"]
+                "plot_manager_list"]
 
 
 class DataFramePlotManager_Serializer(DataElement_Serializer):

--- a/pybleau/app/model/tests/test_base_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_base_dataframe_analyzer.py
@@ -331,6 +331,25 @@ class Analyzer(UnittestTools):
         self.assertEqual(list(analyzer.summary_df.columns), ["a", "c"])
         self.assertEqual(list(analyzer.summary_categorical_df.columns), ["b"])
 
+    def test_keep_index_name_sort_options_synced(self):
+        """ Make sure index_name & sort options update on data update.
+
+        This update may be triggered by programmatic modification of an
+        analyzer or during its deserialization or creation.
+        """
+        analyzer = self.analyzer_klass(source_df=self.df)
+        self.assertEqual(analyzer.index_name, "index")
+        self.assertIn("index", analyzer.sort_by_col_list)
+
+        # Change source_df
+        df = pd.DataFrame({"a": range(11), "b": range(0, 110, 10),
+                           "c": list("abcdeabcaab")}, index=range(11))
+        df.index.name = "new index"
+        analyzer.source_df = df
+        self.assertEqual(analyzer.index_name, "new index")
+        self.assertNotIn("index", analyzer.sort_by_col_list)
+        self.assertIn("new index", analyzer.sort_by_col_list)
+
 
 class SortingDataFrameAnalyzer(UnittestTools):
 

--- a/pybleau/app/model/tests/test_base_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_base_dataframe_analyzer.py
@@ -345,7 +345,10 @@ class Analyzer(UnittestTools):
         df = pd.DataFrame({"a": range(11), "b": range(0, 110, 10),
                            "c": list("abcdeabcaab")}, index=range(11))
         df.index.name = "new index"
-        analyzer.source_df = df
+        with self.assertTraitChanges(analyzer, "index_name"):
+            with self.assertTraitChanges(analyzer, "sort_by_col_list"):
+                analyzer.source_df = df
+
         self.assertEqual(analyzer.index_name, "new index")
         self.assertNotIn("index", analyzer.sort_by_col_list)
         self.assertIn("new index", analyzer.sort_by_col_list)


### PR DESCRIPTION
This ensures that the analyzer's `index_name` and therefore the `sort_cols` options can't get out of sync with the `source_df` no matter the order of attribute assignment when building an Analyzer.