### PR TITLE
Fix: filtered df sorting

### DIFF
--- a/pybleau/app/model/tests/base_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/base_dataframe_analyzer.py
@@ -15,7 +15,8 @@ from pybleau.app.plotting.plot_config import ScatterPlotConfigurator
 
 
 class FilterDataFrameAnalyzer(UnittestTools):
-
+    """ Tests around filtering a DFAnalyzer.
+    """
     def setUp(self):
         self.df = pd.DataFrame({"a": range(11), "b": range(0, 110, 10),
                                 "c": list("abcdeabcaab")})
@@ -190,7 +191,8 @@ class FilterDataFrameAnalyzer(UnittestTools):
 
 
 class SummaryDataFrameAnalyzer(UnittestTools):
-
+    """ Tests around summarizing a DFAnalyzer.
+    """
     def setUp(self):
         self.df = pd.DataFrame({"a": range(11), "b": range(0, 110, 10),
                                 "c": list("abcdeabcaab")})
@@ -264,7 +266,8 @@ class SummaryDataFrameAnalyzer(UnittestTools):
 
 
 class Analyzer(UnittestTools):
-
+    """ Tests around creating a DFAnalyzer.
+    """
     def setUp(self):
         self.df = pd.DataFrame({"a": range(11), "b": range(0, 110, 10),
                                 "c": list("abcdeabcaab")})
@@ -355,7 +358,8 @@ class Analyzer(UnittestTools):
 
 
 class SortingDataFrameAnalyzer(UnittestTools):
-
+    """ Tests around sorting a DFAnalyzer.
+    """
     def setUp(self):
         self.df = pd.DataFrame({"a": range(11), "b": range(0, 110, 10),
                                 "c": list("abcdeabcaab")})
@@ -721,6 +725,7 @@ class DisplayingDataFrameAnalyzer(UnittestTools):
         self.assertIs(analyzer.displayed_df, analyzer.filtered_df)
 
     def test_truncating_data_non_trivial_index(self):
+        import pdb ; pdb.set_trace()
         df = self.df
         df.index = [1, 2, 5, 6, 3, 8, 10, 12, 4, 13, 14]
         analyzer = self.analyzer_klass(source_df=df, num_displayed_rows=100,

--- a/pybleau/app/model/tests/base_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/base_dataframe_analyzer.py
@@ -366,6 +366,9 @@ class SortingDataFrameAnalyzer(UnittestTools):
         self.df2 = pd.DataFrame({"a": [1, 2, 3, 4, 5],
                                  "b": [10, 15, 20, 15, 10]})
 
+        self.unsorted_df = pd.DataFrame({"a": range(5)})
+        self.unsorted_df.index = [1, 2, 5, 6, 3]
+
     def test_sorting_options_no_index_name(self):
         """ Changing the sort_by_col changes the filtered DF and summary DF.
         """
@@ -399,31 +402,29 @@ class SortingDataFrameAnalyzer(UnittestTools):
                     "a" + REVERSED_SUFFIX, "b", "b" + REVERSED_SUFFIX]
         self.assertEqual(analyzer.sort_by_col_list, expected)
 
-    def test_initial_index_sort(self):
-        unsorted_df = pd.DataFrame({"a": range(5)})
-        unsorted_df.index = [1, 2, 5, 6, 3]
-        # By default, the DF is sorted along the index: data_sorted=True
-        analyzer = self.analyzer_klass(source_df=unsorted_df)
+    def test_initial_index_sorted(self):
+        """ By default, the DF is sorted along the index: data_sorted=True. """
+        analyzer = self.analyzer_klass(source_df=self.unsorted_df)
+        self.assertEqual(analyzer.source_df.index.tolist(), [1, 2, 3, 5, 6])
+        self.assertEqual(analyzer.source_df.a.tolist(), [0, 1, 4, 2, 3])
+        self.assertEqual(analyzer.filtered_df.index.tolist(), [1, 2, 3, 5, 6])
+        self.assertEqual(analyzer.filtered_df.a.tolist(), [0, 1, 4, 2, 3])
         self.assertEqual(analyzer.displayed_df.index.tolist(), [1, 2, 3, 5, 6])
         self.assertEqual(analyzer.displayed_df.a.tolist(), [0, 1, 4, 2, 3])
         self.assertEqual(analyzer.sort_by_col, "index")
         self.assertIn(NO_SORTING_ENTRY, analyzer.sort_by_col_list)
 
     def test_turn_off_initial_index_sort(self):
-        unsorted_df = pd.DataFrame({"a": range(5)})
-        unsorted_df.index = [1, 2, 5, 6, 3]
-        # Turn off initial sorting:
-        analyzer = self.analyzer_klass(source_df=unsorted_df,
+        """ Turn off initial sort. """
+        analyzer = self.analyzer_klass(source_df=self.unsorted_df,
                                        data_sorted=False)
         self.assertEqual(analyzer.displayed_df.index.tolist(), [1, 2, 5, 6, 3])
         self.assertEqual(analyzer.displayed_df.a.tolist(), list(range(5)))
         self.assertEqual(analyzer.sort_by_col, NO_SORTING_ENTRY)
 
     def test_sorting_variables_updates_when_source_df_changes(self):
-        unsorted_df = pd.DataFrame({"a": range(5)})
-        unsorted_df.index = [1, 2, 5, 6, 3]
-        # Turn off initial sorting:
-        analyzer = self.analyzer_klass(source_df=unsorted_df,
+        """ The list of sorting options update when the source_df updates. """
+        analyzer = self.analyzer_klass(source_df=self.unsorted_df,
                                        data_sorted=False)
         self.assertEqual(analyzer.displayed_df.index.tolist(), [1, 2, 5, 6, 3])
         self.assertEqual(analyzer.displayed_df.a.tolist(), list(range(5)))
@@ -436,12 +437,44 @@ class SortingDataFrameAnalyzer(UnittestTools):
         self.assertTrue(analyzer.data_sorted)
         self.assertIn(NO_SORTING_ENTRY, analyzer.sort_by_col_list)
 
-        analyzer.source_df = unsorted_df
+        analyzer.source_df = self.unsorted_df
         self.assertIn(NO_SORTING_ENTRY, analyzer.sort_by_col_list)
         self.assertEqual(analyzer.sort_by_col, NO_SORTING_ENTRY)
         self.assertFalse(analyzer.data_sorted)
 
-    def test_sorting_by_columns(self):
+    def test_create_with_sort_by_index_no_filter(self):
+        """ Even if no filter is applied, should allow sorting filtered df. """
+        analyzer = self.analyzer_klass(source_df=self.unsorted_df,
+                                       sort_by_col="index", data_sorted=False)
+        self.assertEqual(analyzer.filter_exp, "")
+        self.assertEqual(analyzer.sort_by_col, "index")
+        assert_frame_equal(analyzer.source_df, self.unsorted_df)
+        self.assertEqual(analyzer.filtered_df.index.tolist(),
+                         sorted(analyzer.filtered_df.index))
+        self.assertEqual(analyzer.displayed_df.index.tolist(),
+                         sorted(analyzer.displayed_df.index))
+
+    def test_create_with_sort_by_col_descending(self):
+        """ Even if no filter is applied, should allow sorting filtered df. """
+        b_vals = [10, 15, 20, 16, 11]
+        a_vals = [1, 2, 3, 4, 5]
+        df = pd.DataFrame({"a": a_vals, "b": b_vals})
+        analyzer = self.analyzer_klass(source_df=df,
+                                       sort_by_col="a" + REVERSED_SUFFIX)
+
+        self.assertEqual(analyzer.filter_exp, "")
+        self.assertEqual(analyzer.sort_by_col, "a" + REVERSED_SUFFIX)
+        assert_frame_equal(analyzer.source_df, df)
+        self.assertEqual(analyzer.filtered_df["a"].tolist(),
+                         a_vals[::-1])
+        self.assertEqual(analyzer.filtered_df["b"].tolist(),
+                         b_vals[::-1])
+        self.assertEqual(analyzer.displayed_df["a"].tolist(),
+                         a_vals[::-1])
+        self.assertEqual(analyzer.displayed_df["b"].tolist(),
+                         b_vals[::-1])
+
+    def test_sorting_by_columns_after_creation(self):
         """ Changing the sort_by_col changes the filtered DF and summary DF.
         """
         b_vals = [10, 15, 20, 16, 11, 12, 21]
@@ -466,7 +499,7 @@ class SortingDataFrameAnalyzer(UnittestTools):
                 with self.assertRaises(TraitError):
                     analyzer.sort_by_col = "BLAH"
 
-    def test_sorting_by_index(self):
+    def test_sorting_by_index_after_creation(self):
         """ Changing the column list changes the filtered DF and summary DF.
         """
         b_vals = [10, 15, 20, 16, 11, 12, 21]
@@ -499,6 +532,25 @@ class SortingDataFrameAnalyzer(UnittestTools):
         assert_frame_equal(analysis.source_df, df)
         assert_frame_equal(analysis.filtered_df, filtered)
         assert_frame_equal(analysis.displayed_df, filtered)
+
+    def test_shuffle(self):
+        df = self.df
+        model = self.analyzer_klass(source_df=df)
+        index0 = list(model.filtered_df.index)
+        model.shuffle_filtered_df()
+        index1 = list(model.filtered_df.index)
+        self.assertNotEqual(index0, index1)
+        self.assertEqual(index0, sorted(index1))
+
+
+class SelectionPlotDataFrameAnalyzer(UnittestTools):
+    """ Tests around data selections and data plotters of a DFAnalyzer.
+    """
+    def setUp(self):
+        self.df = pd.DataFrame({"a": range(11), "b": range(0, 110, 10),
+                                "c": list("abcdeabcaab")})
+        self.df2 = pd.DataFrame({"a": [1, 2, 3, 4, 5],
+                                 "b": [10, 15, 20, 15, 10]})
 
     def test_plotter_selection_connected(self):
         df = self.df
@@ -644,15 +696,6 @@ class SortingDataFrameAnalyzer(UnittestTools):
 
         self.assertEqual(model.selected_idx, [len(df)-1])
 
-    def test_shuffle(self):
-        df = self.df
-        model = self.analyzer_klass(source_df=df)
-        index0 = list(model.filtered_df.index)
-        model.shuffle_filtered_df()
-        index1 = list(model.filtered_df.index)
-        self.assertNotEqual(index0, index1)
-        self.assertEqual(index0, sorted(index1))
-
     # Helper methods ----------------------------------------------------------
 
     def create_plot_manager(self, df=None, n_plots=0):
@@ -725,7 +768,6 @@ class DisplayingDataFrameAnalyzer(UnittestTools):
         self.assertIs(analyzer.displayed_df, analyzer.filtered_df)
 
     def test_truncating_data_non_trivial_index(self):
-        import pdb ; pdb.set_trace()
         df = self.df
         df.index = [1, 2, 5, 6, 3, 8, 10, 12, 4, 13, 14]
         analyzer = self.analyzer_klass(source_df=df, num_displayed_rows=100,

--- a/pybleau/app/model/tests/test_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_dataframe_analyzer.py
@@ -1,59 +1,56 @@
 from unittest import skipIf, TestCase
 import os
 
-from .test_base_dataframe_analyzer import Analyzer, \
-    DisplayingDataFrameAnalyzer, FilterDataFrameAnalyzer, \
+from .base_dataframe_analyzer import Analyzer, DisplayingDataFrameAnalyzer, \
+    FilterDataFrameAnalyzer, SelectionPlotDataFrameAnalyzer, \
     SortingDataFrameAnalyzer, SummaryDataFrameAnalyzer
-
-try:
-    import kiwisolver  # noqa
-    KIWI_AVAILABLE = True
-except ImportError:
-    KIWI_AVAILABLE = False
 
 BACKEND_AVAILABLE = os.environ.get("ETS_TOOLKIT", "qt4") != "null"
 
-if BACKEND_AVAILABLE and KIWI_AVAILABLE:
+if BACKEND_AVAILABLE:
     from pybleau.app.model.dataframe_analyzer import DataFrameAnalyzer
 
-msg = "No UI backend to paint into or no Kiwisolver"
+msg = "No UI backend to paint into"
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestAnalyzer(Analyzer, TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.analyzer_klass = DataFrameAnalyzer
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestFilterDataFrameAnalyzer(FilterDataFrameAnalyzer, TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.analyzer_klass = DataFrameAnalyzer
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestSummaryDataFrameAnalyzer(SummaryDataFrameAnalyzer, TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.analyzer_klass = DataFrameAnalyzer
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestSortingDataFrameAnalyzer(SortingDataFrameAnalyzer, TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.analyzer_klass = DataFrameAnalyzer
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestDisplayingDataFrameAnalyzer(DisplayingDataFrameAnalyzer, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.analyzer_klass = DataFrameAnalyzer
 
+
+@skipIf(not BACKEND_AVAILABLE, msg)
+class TestSelectionPlotDataFrameAnalyzer(SelectionPlotDataFrameAnalyzer,
+                                         TestCase):
     @classmethod
     def setUpClass(cls):
         cls.analyzer_klass = DataFrameAnalyzer

--- a/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
@@ -3,25 +3,20 @@ import os
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
 
-try:
-    import kiwisolver  # noqa
-    KIWI_AVAILABLE = True
-except ImportError:
-    KIWI_AVAILABLE = False
+from .base_dataframe_analyzer import Analyzer, DisplayingDataFrameAnalyzer, \
+    FilterDataFrameAnalyzer, SelectionPlotDataFrameAnalyzer, \
+    SortingDataFrameAnalyzer, SummaryDataFrameAnalyzer
 
 BACKEND_AVAILABLE = os.environ.get("ETS_TOOLKIT", "qt4") != "null"
 
-if BACKEND_AVAILABLE and KIWI_AVAILABLE:
-    from .test_base_dataframe_analyzer import Analyzer, \
-        DisplayingDataFrameAnalyzer, FilterDataFrameAnalyzer, \
-        SortingDataFrameAnalyzer, SummaryDataFrameAnalyzer
+if BACKEND_AVAILABLE:
     from pybleau.app.model.multi_dfs_dataframe_analyzer import \
         MultiDataFrameAnalyzer
 
-msg = "No UI backend to paint into or no Kiwisolver"
+msg = "No UI backend to paint into"
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestAnalyzer(Analyzer, TestCase):
 
     @classmethod
@@ -56,33 +51,37 @@ class TestAnalyzer(Analyzer, TestCase):
             self.analyzer_klass(_source_dfs={"a": self.df, "b": self.df2})
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestFilterDataFrameAnalyzer(FilterDataFrameAnalyzer, TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.analyzer_klass = MultiDataFrameAnalyzer
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestSummaryDataFrameAnalyzer(SummaryDataFrameAnalyzer, TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.analyzer_klass = MultiDataFrameAnalyzer
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestSortingDataFrameAnalyzer(SortingDataFrameAnalyzer, TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.analyzer_klass = MultiDataFrameAnalyzer
 
 
-@skipIf(not BACKEND_AVAILABLE or not KIWI_AVAILABLE, msg)
+@skipIf(not BACKEND_AVAILABLE, msg)
 class TestDisplayingDataFrameAnalyzer(DisplayingDataFrameAnalyzer, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.analyzer_klass = MultiDataFrameAnalyzer
 
+
+@skipIf(not BACKEND_AVAILABLE, msg)
+class TestSelectionPlotDataFrameAnalyzer(SelectionPlotDataFrameAnalyzer,
+                                         TestCase):
     @classmethod
     def setUpClass(cls):
         cls.analyzer_klass = MultiDataFrameAnalyzer


### PR DESCRIPTION
Refactor the sorting of the filtered_df so it can reused during the initialization of that attribute. Otherwise, the sorting isn't done right when requesting the descending order.

Unrelated: remove the check on the presence of the kiwisolver package since it is now available to all versions tested.