### PR TITLE
Fix: x axis finite labels controls

### DIFF
--- a/pybleau/app/plotting/axis_style.py
+++ b/pybleau/app/plotting/axis_style.py
@@ -49,7 +49,7 @@ class AxisStyle(HasStrictTraits):
 
     #: Is there a finite number of labels?
     # (If so, allow forcing the appearance of all of them and label rotation)
-    _text_labels = Bool
+    support_text_labels = Bool
 
     def __init__(self, **traits):
         if "range_low" in traits and "auto_range_low" not in traits:
@@ -83,7 +83,7 @@ class AxisStyle(HasStrictTraits):
                          label="Show all ticks/labels",
                          tooltip="(String labels only)"),
                     show_border=True, label="Labels",
-                    visible_when="_text_labels"
+                    visible_when="support_text_labels"
                 ),
             ),
             resizable=True

--- a/pybleau/app/plotting/axis_style.py
+++ b/pybleau/app/plotting/axis_style.py
@@ -49,7 +49,7 @@ class AxisStyle(HasStrictTraits):
 
     #: Is there a finite number of labels?
     # (If so, allow forcing the appearance of all of them and label rotation)
-    _finite_labels = Bool
+    _text_labels = Bool
 
     def __init__(self, **traits):
         if "range_low" in traits and "auto_range_low" not in traits:
@@ -82,7 +82,7 @@ class AxisStyle(HasStrictTraits):
                     Item('show_all_labels',
                          label="Show all ticks/labels",
                          tooltip="(String labels only)",
-                         visible_when="_finite_labels"),
+                         visible_when="_text_labels"),
                     show_border=True, label="Labels",
                 ),
             ),

--- a/pybleau/app/plotting/axis_style.py
+++ b/pybleau/app/plotting/axis_style.py
@@ -47,7 +47,7 @@ class AxisStyle(HasStrictTraits):
     #: View klass. Override to customize the views, for example their icon
     view_klass = Any(default_value=View)
 
-    #: Is there a finite number of labels?
+    #: Does the axis contain text labels?
     # (If so, allow forcing the appearance of all of them and label rotation)
     support_text_labels = Bool
 

--- a/pybleau/app/plotting/axis_style.py
+++ b/pybleau/app/plotting/axis_style.py
@@ -81,9 +81,9 @@ class AxisStyle(HasStrictTraits):
                          tooltip="(String labels only)"),
                     Item('show_all_labels',
                          label="Show all ticks/labels",
-                         tooltip="(String labels only)",
-                         visible_when="_text_labels"),
+                         tooltip="(String labels only)"),
                     show_border=True, label="Labels",
+                    visible_when="_text_labels"
                 ),
             ),
             resizable=True

--- a/pybleau/app/plotting/axis_style.py
+++ b/pybleau/app/plotting/axis_style.py
@@ -77,11 +77,13 @@ class AxisStyle(HasStrictTraits):
                 ),
                 HGroup(
                     Item('label_rotation',
-                         editor=RangeEditor(low=0, high=360)),
+                         editor=RangeEditor(low=0, high=360),
+                         tooltip="(String labels only)"),
                     Item('show_all_labels',
-                         label="Show all ticks/labels"),
+                         label="Show all ticks/labels",
+                         tooltip="(String labels only)",
+                         visible_when="_finite_labels"),
                     show_border=True, label="Labels",
-                    visible_when="_finite_labels"
                 ),
             ),
             resizable=True

--- a/pybleau/app/plotting/base_factories.py
+++ b/pybleau/app/plotting/base_factories.py
@@ -60,7 +60,7 @@ class BasePlotFactory(HasStrictTraits):
     #: ArrayPlotData supporting the Plot object
     plot_data = Instance(ArrayPlotData)
 
-    #: Styling of the plot and renderer. Passed to renderer creation method
+    #: Styling of the plot and renderer(s)
     plot_style = Instance(BaseXYPlotStyle)
 
     #: Title of the generated plot
@@ -152,10 +152,12 @@ class BasePlotFactory(HasStrictTraits):
                                     positions=np.arange(len(x_labels)),
                                     label_rotation=label_rotation,
                                     tick_generator=tick_generator)
-            plot.x_axis = bottom_axis
-            # Replace in the underlay list too:
-            plot.underlays.pop(0)
+            # Replace in the underlay list...
+            if plot.underlays:
+                plot.underlays.pop(0)
             plot.underlays.insert(0, bottom_axis)
+            # ... and add a handle from the plot object to emulate chaco.Plot
+            plot.x_axis = bottom_axis
 
         plot.x_axis.title = self.x_axis_title
         font_size = x_axis_style.title_style.font_size

--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -289,7 +289,9 @@ class BaseXYPlotStyle(HasStrictTraits):
     # Traits initialization methods -------------------------------------------
 
     def _x_axis_style_default(self):
-        return AxisStyle(axis_name="X", _finite_labels=True)
+        # Not always text labels along x but that's a possibility so enable
+        # text label controls:
+        return AxisStyle(axis_name="X", _text_labels=True)
 
     def _y_axis_style_default(self):
         return AxisStyle(axis_name="Y")

--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -291,7 +291,7 @@ class BaseXYPlotStyle(HasStrictTraits):
     def _x_axis_style_default(self):
         # Not always text labels along x but that's a possibility so enable
         # text label controls:
-        return AxisStyle(axis_name="X", _text_labels=True)
+        return AxisStyle(axis_name="X", support_text_labels=True)
 
     def _y_axis_style_default(self):
         return AxisStyle(axis_name="Y")

--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -289,7 +289,7 @@ class BaseXYPlotStyle(HasStrictTraits):
     # Traits initialization methods -------------------------------------------
 
     def _x_axis_style_default(self):
-        return AxisStyle(axis_name="X")
+        return AxisStyle(axis_name="X", _finite_labels=True)
 
     def _y_axis_style_default(self):
         return AxisStyle(axis_name="Y")

--- a/pybleau/app/plotting/tests/test_plot_styles.py
+++ b/pybleau/app/plotting/tests/test_plot_styles.py
@@ -128,6 +128,7 @@ class TestPlotStyleAsView(TestCase):
 @skipIf(not BACKEND_AVAILABLE, "No UI backend available")
 class TestPlotStyleBehaviors(TestCase):
     def test_default_plot_style_supports_text_x_axis(self):
+        """ Bar plot styles must support text labels along the x axis. """
         style = BarPlotStyle()
         self.assertTrue(style.x_axis_style.support_text_labels)
         self.assertFalse(style.y_axis_style.support_text_labels)

--- a/pybleau/app/plotting/tests/test_plot_styles.py
+++ b/pybleau/app/plotting/tests/test_plot_styles.py
@@ -127,6 +127,11 @@ class TestPlotStyleAsView(TestCase):
 
 @skipIf(not BACKEND_AVAILABLE, "No UI backend available")
 class TestPlotStyleBehaviors(TestCase):
+    def test_default_plot_style_supports_text_x_axis(self):
+        style = BarPlotStyle()
+        self.assertTrue(style.x_axis_style.support_text_labels)
+        self.assertFalse(style.y_axis_style.support_text_labels)
+
     def test_initialize_range(self):
         style = SingleLinePlotStyle()
         plot = Plot(ArrayPlotData(x=[1, 2], y=[3, 4]))

--- a/scripts/explore_dataframe_with_plots.py
+++ b/scripts/explore_dataframe_with_plots.py
@@ -61,6 +61,10 @@ config7.y_col_names = ["Col_1", "Col_2", "Col_4"]
 desc7 = PlotDescriptor(plot_config=config7, plot_title="Plot 7",
                        container_idx=1)
 
+config9 = BarPlotConfigurator(data_source=TEST_DF, plot_title="plot 9")
+config9.x_col_name = "Col_3"
+config9.y_col_name = "Col_4"
+
 config8 = ScatterPlotConfigurator(data_source=TEST_DF)
 config8.x_col_name = "Col_1"
 config8.y_col_name = "Col_2"
@@ -72,15 +76,16 @@ analyzer = DataFrameAnalyzer(source_df=TEST_DF)
 
 plot_manager = DataFramePlotManager(
     contained_plots=[
-        config,
-        config2,
-        config3,
-        config4,
-        config5,
-        cust_plot1,
-        config6,
-        desc7,
-        desc8
+        # config,
+        # config2,
+        # config3,
+        # config4,
+        # config5,
+        # cust_plot1,
+        # config6,
+        # desc7,
+        config9,
+        # desc8
     ],
     data_source=TEST_DF, source_analyzer=analyzer
 )

--- a/scripts/explore_dataframe_with_plots.py
+++ b/scripts/explore_dataframe_with_plots.py
@@ -76,16 +76,16 @@ analyzer = DataFrameAnalyzer(source_df=TEST_DF)
 
 plot_manager = DataFramePlotManager(
     contained_plots=[
-        # config,
-        # config2,
-        # config3,
-        # config4,
-        # config5,
-        # cust_plot1,
-        # config6,
-        # desc7,
+        config,
+        config2,
+        config3,
+        config4,
+        config5,
+        cust_plot1,
+        config6,
+        desc7,
         config9,
-        # desc8
+        desc8
     ],
     data_source=TEST_DF, source_analyzer=analyzer
 )


### PR DESCRIPTION
Bring back text label controls for text x axis. Test by running the new `scripts/explore_dataframe_with_plots.py` and try editing the last bar plot on the first row:
![Screen Shot 2020-08-12 at 10 18 26 PM](https://user-images.githubusercontent.com/593945/90090510-d1964b80-dce9-11ea-8cd4-02f0048425eb.png)

 
Fixes #85 