### PR TITLE
Fix renderer alignment bug when changing style range.

### DIFF
--- a/pybleau/app/plotting/base_factories.py
+++ b/pybleau/app/plotting/base_factories.py
@@ -418,7 +418,7 @@ class StdXYPlotFactory(BasePlotFactory):
             first_renderer = i == 0
             self.add_renderer(plot, desc, style, first_renderer=first_renderer)
 
-        self._align_all_renderers(plot)
+        self.align_all_renderers(plot)
 
     def add_renderer(self, plot, desc, style, first_renderer=False):
         """ Create and add to plot renderer described by desc and style.
@@ -462,8 +462,11 @@ class StdXYPlotFactory(BasePlotFactory):
 
         return renderer
 
-    def _align_all_renderers(self, plot):
-        """ Align all renderers in index and value dimension.
+    def align_all_renderers(self, plot):
+        """ Align all renderers in index and value dimensions to plot's axis.
+
+        This method is used to keep renderers aligned with the displayed axes
+        once their ranges have been set.
         """
         styles = self.plot_style.renderer_styles
         all_renderers = self.renderers.values()

--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -168,6 +168,20 @@ class BaseXYPlotStyle(HasStrictTraits):
     def apply_axis_ranges(self, plot, x_mapper=None, y_mapper=None,
                           second_y_mapper=None):
         """ Apply to the plot's mappers the ranges stored in this style object.
+
+        Parameters
+        ----------
+        plot : Plot, OverlayPlotContainer
+            Plot to apply the style's ranges to.
+
+        x_mapper : Mapper, optional
+            Mapper to apply the x range values to.
+
+        y_mapper : Mapper, optional
+            Mapper to apply the y range values to.
+
+        second_y_mapper : Mapper, optional
+            Mapper to apply the secondary y range values to.
         """
         x_mapper, y_mapper, second_y_mapper = self._get_plot_mappers(
             plot, x_mapper=x_mapper, y_mapper=y_mapper,
@@ -261,6 +275,22 @@ class BaseXYPlotStyle(HasStrictTraits):
     def _get_plot_mappers(self, plot, x_mapper=None, y_mapper=None,
                           second_y_mapper=None):
         """ Retrieve the plot's mappers to synchronize with the style.
+
+        Parameters
+        ----------
+        plot : Plot-like
+            Chaco Plot-like class that holds up to 3 axis attributes to apply
+            style ranges to: x_axis, y_axis and second_y_axis. Each must be an
+            instance of a PlotAxis.
+
+        x_mapper : Mapper
+            Already identified Mapper to align with the x range.
+
+        y_mapper : Mapper
+            Already identified Mapper to align with the y range.
+
+        second_y_mapper : Mapper
+            Already identified Mapper to align with the secondary y range.
         """
         missing_mapper_msg = "The plot is missing the attribute {}. Please " \
                              "provide the mapper explicitly"

--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -291,6 +291,12 @@ class BaseXYPlotStyle(HasStrictTraits):
 
         second_y_mapper : Mapper
             Already identified Mapper to align with the secondary y range.
+
+        Returns
+        -------
+        tuple
+            The x_mapper, y_mapper and secondary_y_mapper found on provided
+            plot.
         """
         missing_mapper_msg = "The plot is missing the attribute {}. Please " \
                              "provide the mapper explicitly"

--- a/pybleau/app/plotting/tests/test_plot_styles.py
+++ b/pybleau/app/plotting/tests/test_plot_styles.py
@@ -5,7 +5,8 @@ from app_common.apptools.testing_utils import assert_obj_gui_works
 
 from chaco.api import ArrayPlotData, Plot
 import pandas as pd
-from pybleau.app.api import DataFramePlotManager
+from pybleau.app.model.dataframe_plot_manager import DataFramePlotManager, \
+    plot_from_config
 from pybleau.app.plotting.api import ScatterPlotConfigurator
 from pybleau.app.plotting.bar_plot_style import BarPlotStyle
 from pybleau.app.plotting.histogram_plot_style import HistogramPlotStyle
@@ -127,7 +128,7 @@ class TestPlotStyleAsView(TestCase):
 
 @skipIf(not BACKEND_AVAILABLE, "No UI backend available")
 class TestPlotStyleBehaviors(TestCase):
-    def test_initialize_range(self):
+    def test_initialize_range_from_manual_plot(self):
         style = SingleLinePlotStyle()
         plot = Plot(ArrayPlotData(x=[1, 2], y=[3, 4]))
         plot.plot(("x", "y"))
@@ -154,7 +155,39 @@ class TestPlotStyleBehaviors(TestCase):
         self.assertEqual(style.y_axis_style.auto_range_low, 3)
         self.assertEqual(style.y_axis_style.auto_range_high, 4)
 
-    def test_initialize_range_with_transform(self):
+    def test_initialize_range_from_factory_result(self):
+        style = BaseColorXYPlotStyle()
+
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4], "z": ["a", "b"]})
+        config = ScatterPlotConfigurator(
+            data_source=df, x_col_name="x", y_col_name="y",
+            z_col_name="z"
+        )
+        plot, _, _ = plot_from_config(config)
+
+        self.assertNotEqual(style.x_axis_style.range_low, 1)
+        self.assertNotEqual(style.x_axis_style.range_high, 2)
+        self.assertNotEqual(style.y_axis_style.range_low, 3)
+        self.assertNotEqual(style.y_axis_style.range_high, 4)
+
+        self.assertNotEqual(style.x_axis_style.auto_range_low, 1)
+        self.assertNotEqual(style.x_axis_style.auto_range_high, 2)
+        self.assertNotEqual(style.y_axis_style.auto_range_low, 3)
+        self.assertNotEqual(style.y_axis_style.auto_range_high, 4)
+
+        style.initialize_axis_ranges(plot)
+
+        self.assertEqual(style.x_axis_style.range_low, 1)
+        self.assertEqual(style.x_axis_style.range_high, 2)
+        self.assertEqual(style.y_axis_style.range_low, 3)
+        self.assertEqual(style.y_axis_style.range_high, 4)
+
+        self.assertEqual(style.x_axis_style.auto_range_low, 1)
+        self.assertEqual(style.x_axis_style.auto_range_high, 2)
+        self.assertEqual(style.y_axis_style.auto_range_low, 3)
+        self.assertEqual(style.y_axis_style.auto_range_high, 4)
+
+    def test_initialize_range_from_manual_plot_with_transform(self):
         style = SingleLinePlotStyle()
         plot = Plot(ArrayPlotData(x=[1.1, 2.1], y=[3.1, 4.1]))
         plot.plot(("x", "y"))
@@ -195,7 +228,7 @@ class TestPlotStyleBehaviors(TestCase):
         self.assertEqual(style.y_axis_style.auto_range_low, 3)
         self.assertEqual(style.y_axis_style.auto_range_high, 4)
 
-    def test_change_plot_range_and_reset(self):
+    def test_reset_axis_range(self):
         style = SingleLinePlotStyle()
         # Initial state:
         self.assertEqual(style.x_axis_style.range_low,


### PR DESCRIPTION
Changing style's axis ranges currently only applied to the first renderer. This fixes that. Bug/fix can be reproduced/tested by running the example script scripts/explore_dataframe_with_plots.py and changing the an axis range on plot 3.

Unrelated: `plot_style` test suite expanded

Fixes #86 