### PR TITLE
Remove check for template manage button

### DIFF
--- a/pybleau/app/ui/base_templates_list_dlg.py
+++ b/pybleau/app/ui/base_templates_list_dlg.py
@@ -1,5 +1,5 @@
 from app_common.traitsui.common_modal_dialogs import BaseDlg
-from traits.api import Bool, Instance, Property, List, Str, observe
+from traits.api import Instance, List, Str, observe
 from traitsui.api import Handler, Action
 
 from pybleau.app.model.plot_template_manager import PlotTemplateManager

--- a/pybleau/app/ui/base_templates_list_dlg.py
+++ b/pybleau/app/ui/base_templates_list_dlg.py
@@ -27,17 +27,10 @@ class BaseTemplateListDlg(BaseDlg):
     #: Button to bring up the plot templates manager view
     man_temp_button = Instance(Action)
 
-    #: Boolean flag for whether templates exist
-    templates_exist = Property(Bool)
-
     # Traits initialization methods -------------------------------------------
-
-    def _get_templates_exist(self) -> bool:
-        return len(self.model.names) > 0
 
     def _man_temp_button_default(self):
         return Action(name='Manage templates...',
-                      enabled_when='templates_exist',
                       action='do_manage')
 
     # Traits listeners --------------------------------------------------------

--- a/pybleau/app/ui/tests/test_base_template_list_dlg.py
+++ b/pybleau/app/ui/tests/test_base_template_list_dlg.py
@@ -12,12 +12,6 @@ class TestBaseTemplateListDlg(TestCase):
         model.names = MagicMock(list)
         self.accessor = BaseTemplateListDlg(model=model)
 
-    def test_templates_exist_returns_correct(self):
-        self.accessor.model.names = list('abc')
-        self.assertTrue(self.accessor.templates_exist)
-        self.accessor.model.names = []
-        self.assertFalse(self.accessor.templates_exist)
-
     def test_reconcile_plot_types_list(self):
         current_list = list('abc')
         self.accessor.plot_types = current_list


### PR DESCRIPTION
The `templates_exist` flag for the `Manage templates...` button was hindering discoverability of the full plot template feature, so it was removed. Additionally, it was the cause of a bug where the button was disabled even when templates existed. Disabling the button was deemed unnecessary.
Fixes KBIbiopharma/particle_data_viewer/issues/734