### PR TITLE
Maint: switch to pytest for running tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = traitsui
+source = pybleau
 omit = */tests/*
 
 [report]

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,3 @@ install:
 script:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
   - edm run -- python etstool.py flake8
-
-after_success:
-  - edm run -- coverage combine
-  - edm run -- pip install codecov
-  - edm run -- codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,6 @@ install:
   - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit; done; fi
 script:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
+after_success:
   - edm run -- python etstool.py flake8
+  # Add upload of coverage file to coverage service

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,3 @@ test_script:
   - appveyor-run.cmd test %runtime% %toolkits%
 on_success:
   - appveyor-run.cmd flake8 %runtime% %toolkits%
-  - edm run -- coverage combine
-  - edm run -- pip install codecov
-  - edm run -- codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,5 +32,6 @@ install:
   - appveyor-run.cmd install %runtime% %toolkits%
 test_script:
   - appveyor-run.cmd test %runtime% %toolkits%
-on_success:
   - appveyor-run.cmd flake8 %runtime% %toolkits%
+on_success:
+  # Add upload of coverage file to coverage service

--- a/ci/pip_requirements.json
+++ b/ci/pip_requirements.json
@@ -1,0 +1,4 @@
+[
+  "pytest",
+  "pytest-cov"
+]

--- a/etstool.py
+++ b/etstool.py
@@ -201,6 +201,23 @@ def install(runtime, toolkit, environment, edm_dir, editable):
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
 
+    if source_dependencies:
+        # Force remove if it was installed via EDM:
+        cmd_fmt = "{edm_dir}edm plumbing remove-package --environment " \
+                  "{environment} --force "
+        commands = [cmd_fmt+dependency
+                    for dependency in source_dependencies.keys()]
+        execute(commands, parameters)
+
+        source_pkgs = source_dependencies.values()
+        commands = [
+            "python -m pip install {pkg} --no-deps".format(pkg=pkg)
+            for pkg in source_pkgs
+        ]
+        commands = ["{edm_dir}edm run -e {environment} -- " + command
+                    for command in commands]
+        execute(commands, parameters)
+
     if pip_dependencies:
         commands = [
             "python -m pip install {pkg}".format(pkg=pkg)

--- a/etstool.py
+++ b/etstool.py
@@ -243,10 +243,8 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
          target, cov):
     """ Run the test suite in a given environment with the specified toolkit.
     """
-    cov_file = "test_coverage.xml"
-
     parameters = get_parameters(
-        runtime, toolkit, environment, edm_dir=edm_dir, cov_file=cov_file,
+        runtime, toolkit, environment, edm_dir=edm_dir,
         test_pattern=test_pattern, num_slowest=num_slowest, target=target
     )
     environ = environment_vars.get(toolkit, {}).copy()
@@ -256,8 +254,8 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
         commands = [
             "{edm_dir}edm run -e {environment} -- pytest "
             "--cov-config=.coveragerc --durations={num_slowest} "
-            "--cov={PKG_NAME} --cov-report=xml:{cov_file} "
-            "--cov-report term {target}",
+            "--cov={PKG_NAME} --cov-report=xml:test_coverage.xml "
+            "--cov-report=html:test_coverage.html --cov-report term {target}",
         ]
     else:
         commands = [

--- a/etstool.py
+++ b/etstool.py
@@ -112,6 +112,10 @@ for dep in dependencies:
         dependencies = dependencies - {dep}
         break
 
+source_dependencies = {
+    "app_common": "git+https://github.com/KBIbiopharma/app_common#egg=app_common",
+}
+
 if os.path.isfile(PIP_DEPENDENCIES):
     pip_dependencies = json.load(open(PIP_DEPENDENCIES))
 else:

--- a/etstool.py
+++ b/etstool.py
@@ -243,8 +243,10 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
          target, cov):
     """ Run the test suite in a given environment with the specified toolkit.
     """
+    cov_file = "test_coverage.xml"
+
     parameters = get_parameters(
-        runtime, toolkit, environment, edm_dir=edm_dir,
+        runtime, toolkit, environment, edm_dir=edm_dir, cov_file=cov_file,
         test_pattern=test_pattern, num_slowest=num_slowest, target=target
     )
     environ = environment_vars.get(toolkit, {}).copy()
@@ -253,8 +255,9 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
     if cov:
         commands = [
             "{edm_dir}edm run -e {environment} -- pytest "
-            "--cov-config=.coveragerc --cov={PKG_NAME} "
-            "--durations={num_slowest} {target}",
+            "--cov-config=.coveragerc --durations={num_slowest} "
+            "--cov={PKG_NAME} --cov-report=xml:{cov_file} "
+            "--cov-report term {target}",
         ]
     else:
         commands = [
@@ -267,7 +270,6 @@ def test(runtime, toolkit, edm_dir, environment, test_pattern, num_slowest,
     # that directory, plus coverage has a bug that means a non-local coverage
     # file doesn't get populated correctly.
     click.echo("Running tests in '{environment}'".format(**parameters))
-    #with do_in_tempdir(files=['.coveragerc'], capture_files=['./.coverage*']):
     os.environ.update(environ)
     execute(commands, parameters)
     click.echo('Done test')


### PR DESCRIPTION
Switching to pytest for running the test suite to allow:
- coverage report generation in XML and HTML
- test duration computation
- unittest's search is finicky, relying on `__init__` files inside test sub-packages.