### PR TITLE
Feature: add dict to store column notes/descriptions

### DIFF
--- a/pybleau/app/io/serializer.py
+++ b/pybleau/app/io/serializer.py
@@ -43,7 +43,7 @@ class DataFrameAnalyzer_Serializer(DataElement_Serializer):
     def attr_names_to_serialize(self, obj):
         return ['name', 'uuid', 'source_df', 'filter_exp', 'summary_index',
                 'sort_by_col', 'data_selected', 'num_displayed_rows',
-                "plot_manager_list"]
+                "plot_manager_list", "column_descr"]
 
 
 class MultiDataFrameAnalyzer_Serializer(DataFrameAnalyzer_Serializer):

--- a/pybleau/app/io/tests/test_analyzer_roundtrip.py
+++ b/pybleau/app/io/tests/test_analyzer_roundtrip.py
@@ -112,7 +112,7 @@ class BaseAnalysisRoundTrip(object):
                                           ignore=skips, **kwargs)
 
 
-class TestRoundTripBareAnalyzer(TestCase, BaseAnalysisRoundTrip):
+class TestRoundTripMultiDfAnalyzer(TestCase, BaseAnalysisRoundTrip):
     """ Serialize an analyzer containing plots.
     """
     def setUp(self):

--- a/pybleau/app/model/dataframe_analyzer.py
+++ b/pybleau/app/model/dataframe_analyzer.py
@@ -3,8 +3,8 @@ from pandas import concat, DataFrame
 import numpy as np
 from functools import partial
 
-from traits.api import Bool, cached_property, Callable, Enum, Event, Instance,\
-    Int, List, on_trait_change, Property, Str
+from traits.api import Bool, cached_property, Callable, Dict, Enum, Event, \
+    Instance, Int, List, on_trait_change, Property, Str
 
 from app_common.std_lib.str_utils import add_suffix_if_exists, sanitize_string
 from app_common.model_tools.data_element import DataElement
@@ -50,6 +50,9 @@ class DataFrameAnalyzer(DataElement):
 
     #: **Copy** of the data to analyze, where column names have been sanitized
     source_df = Instance(DataFrame)
+
+    #: Custom notes describing the columns of the source_df
+    column_descr = Dict
 
     #: Result of filtering the source_df with the filter_exp expression
     filtered_df = Instance(DataFrame)

--- a/pybleau/app/model/dataframe_analyzer.py
+++ b/pybleau/app/model/dataframe_analyzer.py
@@ -369,7 +369,7 @@ class DataFrameAnalyzer(DataElement):
         else:
             self.sort_by_col = self.index_name
 
-        self.update_column_descriptions()
+        self._update_column_descriptions()
 
     def _sort_by_col_changed(self, new):
         self.filtered_df = self._sort_df_by(self.filtered_df, new)

--- a/pybleau/app/model/dataframe_analyzer.py
+++ b/pybleau/app/model/dataframe_analyzer.py
@@ -4,7 +4,7 @@ import numpy as np
 from functools import partial
 
 from traits.api import Bool, cached_property, Callable, Dict, Enum, Event, \
-    Instance, Int, List, on_trait_change, Property, Str
+    Instance, Int, List, observe, on_trait_change, Property, Str
 
 from app_common.std_lib.str_utils import add_suffix_if_exists, sanitize_string
 from app_common.model_tools.data_element import DataElement
@@ -201,6 +201,15 @@ class DataFrameAnalyzer(DataElement):
         self.filtered_df = self.filtered_df.sample(frac=1)
 
     # Traits Listeners --------------------------------------------------------
+
+    @observe("column_descr:items")
+    def check_col_descr_change(self, event):
+        for key, value in event.added.items():
+            if key not in self.source_df.columns:
+                msg = f"Note added for invalid column {key}. Removing it... " \
+                    f"(Note was: {value})"
+                logger.error(msg)
+                self.column_descr.pop(key)
 
     @on_trait_change("plot_manager_list.index_selected[]", post_init=True)
     def update_selected_idx(self, object, name, old, new):

--- a/pybleau/app/model/dataframe_analyzer.py
+++ b/pybleau/app/model/dataframe_analyzer.py
@@ -369,6 +369,8 @@ class DataFrameAnalyzer(DataElement):
         else:
             self.sort_by_col = self.index_name
 
+        self.update_column_descriptions()
+
     def _sort_by_col_changed(self, new):
         self.filtered_df = self._sort_df_by(self.filtered_df, new)
         # Remap the selections
@@ -407,6 +409,15 @@ class DataFrameAnalyzer(DataElement):
         return df
 
     # Private interface -------------------------------------------------------
+
+    def _update_column_descriptions(self):
+        """ Remove column descriptions if a column has been removed.
+        """
+        descriptions = list(self.column_descr.keys())
+        columns_present = set(self.source_df.columns)
+        for col_name in descriptions:
+            if col_name not in columns_present:
+                self.column_descr.pop(col_name)
 
     @staticmethod
     def _clean_filter_exp(expr):

--- a/pybleau/app/model/tests/base_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/base_dataframe_analyzer.py
@@ -357,6 +357,24 @@ class Analyzer(UnittestTools):
         self.assertNotIn("index", analyzer.sort_by_col_list)
         self.assertIn("new index", analyzer.sort_by_col_list)
 
+    def test_add_column_descriptions(self):
+        analyzer = self.analyzer_klass(source_df=self.df)
+        self.assertEqual(analyzer.column_descr, {})
+        analyzer.column_descr["a"] = "Cool column!"
+        self.assertEqual(set(analyzer.column_descr.keys()), {"a"})
+        analyzer.column_descr["b"] = "Another cool column!"
+        self.assertEqual(set(analyzer.column_descr.keys()), {"a", "b"})
+        analyzer.column_descr["a"] = "Actually, not so much"
+        self.assertEqual(set(analyzer.column_descr.keys()), {"a", "b"})
+        self.assertEqual(analyzer.column_descr["a"], "Actually, not so much")
+
+    def test_add_column_descriptions_bad_col_name(self):
+        analyzer = self.analyzer_klass(source_df=self.df)
+        analyzer.column_descr["NON-EXISTENT"] = "Cool column!"
+        self.assertEqual(analyzer.column_descr, {})
+        analyzer.column_descr["a"] = "Cool column!"
+        self.assertEqual(set(analyzer.column_descr.keys()), {"a"})
+
 
 class SortingDataFrameAnalyzer(UnittestTools):
     """ Tests around sorting a DFAnalyzer.

--- a/pybleau/app/model/tests/base_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/base_dataframe_analyzer.py
@@ -375,6 +375,15 @@ class Analyzer(UnittestTools):
         analyzer.column_descr["a"] = "Cool column!"
         self.assertEqual(set(analyzer.column_descr.keys()), {"a"})
 
+    def test_remove_column_description_when_remove_source_df_col(self):
+        analyzer = self.analyzer_klass(source_df=self.df)
+        self.assertEqual(analyzer.column_descr, {})
+        analyzer.column_descr["a"] = "Cool column!"
+        analyzer.column_descr["b"] = "Another cool column!"
+        # Remove a column from the source df:
+        analyzer.source_df = self.df["a", "c"]
+        self.assertNotIn("b", set(analyzer.column_descr.keys()))
+
 
 class SortingDataFrameAnalyzer(UnittestTools):
     """ Tests around sorting a DFAnalyzer.

--- a/pybleau/app/model/tests/base_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/base_dataframe_analyzer.py
@@ -381,7 +381,7 @@ class Analyzer(UnittestTools):
         analyzer.column_descr["a"] = "Cool column!"
         analyzer.column_descr["b"] = "Another cool column!"
         # Remove a column from the source df:
-        analyzer.source_df = self.df["a", "c"]
+        analyzer.source_df = self.df[["a", "c"]]
         self.assertNotIn("b", set(analyzer.column_descr.keys()))
 
 

--- a/pybleau/app/model/tests/base_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/base_dataframe_analyzer.py
@@ -375,15 +375,6 @@ class Analyzer(UnittestTools):
         analyzer.column_descr["a"] = "Cool column!"
         self.assertEqual(set(analyzer.column_descr.keys()), {"a"})
 
-    def test_remove_column_description_when_remove_source_df_col(self):
-        analyzer = self.analyzer_klass(source_df=self.df)
-        self.assertEqual(analyzer.column_descr, {})
-        analyzer.column_descr["a"] = "Cool column!"
-        analyzer.column_descr["b"] = "Another cool column!"
-        # Remove a column from the source df:
-        analyzer.source_df = self.df[["a", "c"]]
-        self.assertNotIn("b", set(analyzer.column_descr.keys()))
-
 
 class SortingDataFrameAnalyzer(UnittestTools):
     """ Tests around sorting a DFAnalyzer.

--- a/pybleau/app/model/tests/test_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_dataframe_analyzer.py
@@ -19,6 +19,15 @@ class TestAnalyzer(Analyzer, TestCase):
     def setUpClass(cls):
         cls.analyzer_klass = DataFrameAnalyzer
 
+    def test_remove_column_description_when_remove_source_df_col(self):
+        analyzer = self.analyzer_klass(source_df=self.df)
+        self.assertEqual(analyzer.column_descr, {})
+        analyzer.column_descr["a"] = "Cool column!"
+        analyzer.column_descr["b"] = "Another cool column!"
+        # Remove a column from the source df:
+        analyzer.source_df = self.df[["a", "c"]]
+        self.assertNotIn("b", set(analyzer.column_descr.keys()))
+
 
 @skipIf(not BACKEND_AVAILABLE, msg)
 class TestFilterDataFrameAnalyzer(FilterDataFrameAnalyzer, TestCase):

--- a/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
@@ -23,6 +23,15 @@ class TestAnalyzer(Analyzer, TestCase):
     def setUpClass(cls):
         cls.analyzer_klass = MultiDataFrameAnalyzer
 
+    def test_remove_column_description_when_remove_source_df_col(self):
+        analyzer = self.analyzer_klass(_source_dfs={0: self.df})
+        self.assertEqual(analyzer.column_descr, {})
+        analyzer.column_descr["a"] = "Cool column!"
+        analyzer.column_descr["b"] = "Another cool column!"
+        # Remove a column from the source df:
+        analyzer._source_dfs[0] = self.df[["a", "c"]]
+        self.assertNotIn("b", set(analyzer.column_descr.keys()))
+
     def test_create_inconsistent_df_cols_map(self):
         with self.assertRaises(ValueError):
             self.analyzer_klass(source_df=self.df, _source_df_columns={})


### PR DESCRIPTION
- Adds a dict called `column_descr` to the analyzer to store free form column notes/descriptions.
- Keys added must be a column of the `source_df` or the entry will be removed.

Unrelated: added an assertion in the DFanalyzer tests to make sure that `uuid`s don't get lost during serialization.