### PR TITLE
Enh: source df management

### DIFF
--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd
 
-from traits.api import Dict, Instance, Property
+from traits.api import Dict, Event, Instance, Property
 
 from .dataframe_analyzer import copy_and_sanitize, DataFrameAnalyzer
 
@@ -15,7 +15,8 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
     # Data storage attributes -------------------------------------------------
 
     #: Resulting proxy dataframe built from the dataframe parts
-    source_df = Property(Instance(pd.DataFrame), depends_on="_source_dfs[]")
+    source_df = Property(Instance(pd.DataFrame),
+                         depends_on="_source_dfs[], _source_dfs_changed")
 
     #: Maps dataframe name to dataframe
     _source_dfs = Dict
@@ -25,6 +26,8 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
 
     #: Maps a column name to the dataframe it is located in
     _column_loc = Dict
+
+    _source_dfs_changed = Event
 
     def __init__(self, convert_source_dtypes=False, data_sorted=True,
                  **traits):
@@ -91,8 +94,27 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
 
     # Public interface --------------------------------------------------------
 
+    def concat_to_source_df(self, new_df, **kwargs):
+        """ Concatenate potentially unaligned dataframe to the source_df.
+
+        The index of the input DF must be a subset of the source_df's index,
+        and the alignment will be done using it.
+        """
+        # Align in the index dimension:
+        if not (self.source_df.index == new_df.index).all():
+            new_df = pd.merge(self.source_df, new_df, left_index=True,
+                              right_index=True, how="left")[new_df.columns]
+        for col in new_df:
+            self.set_source_df_col(col, new_df[col], **kwargs)
+
+        self._source_dfs_changed = True
+
     def set_source_df_col(self, col, value, target_df=None):
         """ Set a DF column to a value or add a new column to one of the DFs.
+
+        Note: if a new column is created, this method doesn't issue any
+        notification for the source_df to be re-cololected, so afterwards,
+        it should be issued explicitely, using the `_source_dfs_changed` event.
 
         Parameters
         ----------
@@ -115,6 +137,7 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
                 raise ValueError(msg)
 
             target_df = self._source_dfs[target_df]
+            self._column_loc[col] = target_df
 
         target_df[col] = value
 

--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -101,7 +101,10 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
         and the alignment will be done using it.
         """
         # Align in the index dimension:
-        if not (self.source_df.index == new_df.index).all():
+        idx_len = len(self.source_df.index)
+        idx_mismatch = len(new_df.index) != idx_len or \
+            not (self.source_df.index == new_df.index).all()
+        if idx_mismatch:
             new_df = pd.merge(self.source_df, new_df, left_index=True,
                               right_index=True, how="left")[new_df.columns]
         for col in new_df:

--- a/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
@@ -1,6 +1,8 @@
 from unittest import skipIf, TestCase
 import os
 import pandas as pd
+import numpy as np
+from numpy.testing import assert_array_equal
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
 from .base_dataframe_analyzer import Analyzer, DisplayingDataFrameAnalyzer, \
@@ -91,6 +93,52 @@ class TestAnalyzer(Analyzer, TestCase):
         # Now, this is supposed to work:
         analyzer.set_source_df_col("NEW_COL", "xyz", target_df="b")
         self.assertIn("NEW_COL", analyzer.source_df.columns)
+
+    def test_concat_to_source_df(self):
+        analyzer = self.analyzer_klass(_source_dfs={"a": self.df,
+                                                    "b": self.df3})
+        new_df = pd.DataFrame({"NEW_COL": range(0, 22, 2),
+                               "NEW_COL2": range(11)}, index=self.df.index)
+        with self.assertRaises(ValueError):
+            # This has to fail because a new column is supposed to be created
+            # but no target DF is specified:
+            analyzer.concat_to_source_df(new_df)
+
+        # Now, this is supposed to work:
+        analyzer.concat_to_source_df(new_df, target_df="a")
+        self.assertIn("NEW_COL", analyzer._source_dfs["a"].columns)
+        self.assertIn("NEW_COL2", analyzer._source_dfs["a"].columns)
+        self.assertIn("NEW_COL", analyzer.source_df.columns)
+        self.assertIn("NEW_COL2", analyzer.source_df.columns)
+        self.assertIn("NEW_COL", analyzer.filtered_df.columns)
+        self.assertIn("NEW_COL2", analyzer.filtered_df.columns)
+
+    def test_concat_to_source_df_misaligned(self):
+        analyzer = self.analyzer_klass(_source_dfs={"a": self.df,
+                                                    "b": self.df3})
+        new_df = pd.DataFrame({"NEW_COL": range(0, 22, 4),
+                               "NEW_COL2": range(6)}, index=self.df.index[::2])
+        with self.assertRaises(ValueError):
+            # This has to fail because a new column is supposed to be created
+            # but no target DF is specified:
+            analyzer.concat_to_source_df(new_df)
+
+        # Now, this is supposed to work:
+        analyzer.concat_to_source_df(new_df, target_df="a")
+        self.assertIn("NEW_COL", analyzer._source_dfs["a"].columns)
+        self.assertIn("NEW_COL2", analyzer._source_dfs["a"].columns)
+        self.assertIn("NEW_COL", analyzer.source_df.columns)
+        self.assertIn("NEW_COL2", analyzer.source_df.columns)
+        self.assertIn("NEW_COL", analyzer.filtered_df.columns)
+        self.assertIn("NEW_COL2", analyzer.filtered_df.columns)
+
+        # Alignment was done:
+        expected = np.array([0, np.nan,  4, np.nan,  8, np.nan, 12, np.nan, 16,
+                             np.nan, 20])
+        assert_array_equal(analyzer.source_df["NEW_COL"].values, expected)
+        expected = np.array([0, np.nan, 1, np.nan, 2, np.nan, 3, np.nan, 4,
+                             np.nan, 5])
+        assert_array_equal(analyzer.source_df["NEW_COL2"].values, expected)
 
 
 @skipIf(not BACKEND_AVAILABLE, msg)


### PR DESCRIPTION
Support adding multiple columns to the `source_df` with a new `concat_to_source_df`. Only defined in the `MultiDfsAnalyzer`, at least for now.