### PR TITLE
Improve concatenating DF

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -533,7 +533,7 @@ def get_parameters(runtime, toolkit, environment, **adtl_params):
         raise RuntimeError(msg.format(**parameters))
 
     if environment is None:
-        env_pattern = PKG_NAME + '-test-{toolkit}-py{runtime}'
+        env_pattern = PKG_NAME + '-develop-{toolkit}-py{runtime}'
         parameters['environment'] = env_pattern.format(**parameters)
         parameters['environment'] = parameters['environment'].replace(".", "")
     return parameters

--- a/etstool.py
+++ b/etstool.py
@@ -533,7 +533,7 @@ def get_parameters(runtime, toolkit, environment, **adtl_params):
         raise RuntimeError(msg.format(**parameters))
 
     if environment is None:
-        env_pattern = PKG_NAME + '-develop-{toolkit}-py{runtime}'
+        env_pattern = PKG_NAME + '-test-{toolkit}-py{runtime}'
         parameters['environment'] = env_pattern.format(**parameters)
         parameters['environment'] = parameters['environment'].replace(".", "")
     return parameters

--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -105,8 +105,7 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
         """ Concatenate potentially unaligned dataframe to the source_df.
 
         The index of the input DF must be a subset of the source_df's index,
-        and the alignment will be done using it. Note that this method assumes
-        that the new_df contains only new columns.
+        and the alignment will be done using it.
         """
         # Align in the index dimension:
         idx_len = len(self.source_df.index)
@@ -116,6 +115,10 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
             new_df = new_df.reindex(self.source_df.index)
 
         for col in new_df:
+            if col in self._column_loc:
+                # Add a prefix to avoid collision with an existing column
+                col += "_y"
+
             self.set_source_df_col(col, new_df[col], **kwargs)
 
         self._source_dfs_changed = True

--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -105,8 +105,8 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
         idx_mismatch = len(new_df.index) != idx_len or \
             not (self.source_df.index == new_df.index).all()
         if idx_mismatch:
-            new_df = pd.merge(self.source_df, new_df, left_index=True,
-                              right_index=True, how="left")[new_df.columns]
+            new_df = new_df.reindex(self.source_df.index)
+
         for col in new_df:
             self.set_source_df_col(col, new_df[col], **kwargs)
 

--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -117,9 +117,11 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
         for col in new_df:
             if col in self._column_loc:
                 # Add a prefix to avoid collision with an existing column
-                col += "_y"
+                target_col = col + "_y"
+            else:
+                target_col = col
 
-            self.set_source_df_col(col, new_df[col], **kwargs)
+            self.set_source_df_col(target_col, new_df[col], **kwargs)
 
         self._source_dfs_changed = True
 

--- a/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
@@ -140,6 +140,24 @@ class TestAnalyzer(Analyzer, TestCase):
                              np.nan, 5])
         assert_array_equal(analyzer.source_df["NEW_COL2"].values, expected)
 
+    def test_concat_to_source_df(self):
+        analyzer = self.analyzer_klass(_source_dfs={"a": self.df,
+                                                    "b": self.df3})
+        initial_a_values = self.df["a"].values
+        new_df = pd.DataFrame({"NEW_COL": range(0, 22, 2),
+                               "a": range(11)}, index=self.df.index)
+        analyzer.concat_to_source_df(new_df, target_df="a")
+        for df in [analyzer._source_dfs["a"], analyzer.source_df,
+                   analyzer.filtered_df]:
+            # New column is added:
+            self.assertIn("NEW_COL", df.columns)
+            # New a column is appended a suffix and added:
+            self.assertIn("a_y", df.columns)
+            assert_array_equal(df["a_y"].values, np.arange(11))
+            # Existing a column is unchanged:
+            self.assertIn("a", df.columns)
+            assert_array_equal(df["a"].values, initial_a_values)
+
 
 @skipIf(not BACKEND_AVAILABLE, msg)
 class TestFilterDataFrameAnalyzer(FilterDataFrameAnalyzer, TestCase):

--- a/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
@@ -140,7 +140,7 @@ class TestAnalyzer(Analyzer, TestCase):
                              np.nan, 5])
         assert_array_equal(analyzer.source_df["NEW_COL2"].values, expected)
 
-    def test_concat_to_source_df(self):
+    def test_concat_to_source_df_overlapping_col(self):
         analyzer = self.analyzer_klass(_source_dfs={"a": self.df,
                                                     "b": self.df3})
         initial_a_values = self.df["a"].values

--- a/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
@@ -145,7 +145,7 @@ class TestAnalyzer(Analyzer, TestCase):
                                                     "b": self.df3})
         initial_a_values = self.df["a"].values
         new_df = pd.DataFrame({"NEW_COL": range(0, 22, 2),
-                               "a": range(11)}, index=self.df.index)
+                               "a": list("sjdfkshfkah")}, index=self.df.index)
         analyzer.concat_to_source_df(new_df, target_df="a")
         for df in [analyzer._source_dfs["a"], analyzer.source_df,
                    analyzer.filtered_df]:
@@ -153,7 +153,7 @@ class TestAnalyzer(Analyzer, TestCase):
             self.assertIn("NEW_COL", df.columns)
             # New a column is appended a suffix and added:
             self.assertIn("a_y", df.columns)
-            assert_array_equal(df["a_y"].values, np.arange(11))
+            self.assertEqual(list(df["a_y"]), list("sjdfkshfkah"))
             # Existing a column is unchanged:
             self.assertIn("a", df.columns)
             assert_array_equal(df["a"].values, initial_a_values)


### PR DESCRIPTION
  1. Improve how reindexing is done: `pd.merge` is replaced by `pd.reindex` which is faster and clearer.
  2. Improve handling of overlapping columns by adding a suffix.