### PR TITLE
Create a generic version of the ScrollableButtonListView

### DIFF
--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -157,7 +157,7 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
             self._column_loc[col] = target_df
 
         target_df[col] = value
-        if not new_col_created:
+        if new_col_created:
             self._source_dfs_changed = True
 
     def set_source_df_val(self, index, col, value):

--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -157,7 +157,7 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
             self._column_loc[col] = target_df
 
         target_df[col] = value
-        if new_col_created:
+        if not new_col_created:
             self._source_dfs_changed = True
 
     def set_source_df_val(self, index, col, value):

--- a/pybleau/app/ui/filter_expression_editor.py
+++ b/pybleau/app/ui/filter_expression_editor.py
@@ -11,8 +11,7 @@ from traitsui.api import VGroup, Item, OKCancelButtons, View, Tabbed, \
     HSplit, StatusItem, HGroup, Spring
 from traitsui.editors import InstanceEditor
 
-from pybleau.app.utils.scrollable_button_list_view import \
-    ScrollableButtonListView
+from pybleau.app.utils.button_list_view import ScrollableButtonListView
 
 COPY_TO_CLIPBOARD = "copy to clipboard"
 APPEND_TO_FILTER = "append to filter"

--- a/pybleau/app/utils/button_list_view.py
+++ b/pybleau/app/utils/button_list_view.py
@@ -62,4 +62,4 @@ class ButtonListView(HasStrictTraits):
 
 
 class ScrollableButtonListView(ButtonListView):
-    scrollable = True
+    scrollable = Bool(True)

--- a/pybleau/app/utils/button_list_view.py
+++ b/pybleau/app/utils/button_list_view.py
@@ -1,8 +1,10 @@
 from traits.api import HasStrictTraits, Dict, Callable, Any, Str, List, Button
-from traitsui.api import VGroup, Item, View
+from traits.trait_types import Bool
+from traitsui.api import Group, Item, View
+from traitsui.ui_traits import Orientation
 
 
-class ScrollableButtonListView(HasStrictTraits):
+class ButtonListView(HasStrictTraits):
     """ Provides a view for a dict of str:str conversions to Buttons
 
     Give this class a `dict`, and it will turn those `key:value` pairs
@@ -21,17 +23,28 @@ class ScrollableButtonListView(HasStrictTraits):
     #: Class to use to create TraitsUI window to open controls
     view_klass = Any(default_value=View)
 
-    #: Name for the VGroup
+    #: Option setting the orientation of the buttons (default: "vertical")
+    orientation = Orientation
+
+    #: Name for the List Group
     group_label = Str
+
+    #: Flag to set whether to allow scrolling
+    scrollable = Bool(False)
 
     #: Internal list of trait names
     _trait_names = List
 
-    def __init__(self, traits_and_names, handler, group_label="", **traits):
-        super(ScrollableButtonListView, self).__init__(**traits)
+    #: List of tooltips (in the same order as `traits_and_names`) for buttons
+    tooltips = List
+
+    def __init__(self, traits_and_names, handler, group_label="",
+                 tooltips=[], **traits):
+        super(ButtonListView, self).__init__(**traits)
         self.traits_and_names = traits_and_names
         self.handler = handler
         self.group_label = group_label
+        self.tooltips = tooltips
         self._make_trait_names()
 
     def _make_trait_names(self):
@@ -44,7 +57,14 @@ class ScrollableButtonListView(HasStrictTraits):
     def traits_view(self):
         items = [Item(n, show_label=False) for n in self._trait_names]
 
+        for i, tip in enumerate(self.tooltips):
+            items[i].tooltip = tip
+
         return self.view_klass(
-            VGroup(*items, label=self.group_label),
-            scrollable=True
+            Group(*items, label=self.group_label,
+                  orientation=self.orientation), scrollable=self.scrollable
         )
+
+
+class ScrollableButtonListView(ButtonListView):
+    scrollable = True

--- a/pybleau/app/utils/button_list_view.py
+++ b/pybleau/app/utils/button_list_view.py
@@ -38,13 +38,8 @@ class ButtonListView(HasStrictTraits):
     #: List of tooltips (in the same order as `traits_and_names`) for buttons
     tooltips = List
 
-    def __init__(self, traits_and_names, handler, group_label="",
-                 tooltips=[], **traits):
+    def __init__(self, **traits):
         super(ButtonListView, self).__init__(**traits)
-        self.traits_and_names = traits_and_names
-        self.handler = handler
-        self.group_label = group_label
-        self.tooltips = tooltips
         self._make_trait_names()
 
     def _make_trait_names(self):


### PR DESCRIPTION
Added a generic version of the `ScrollableButtonListView` called `ButtonListView` that does not implicitly allow scrolling. Also generalized the orientation ("horizontal" or "vertical")