### PR TITLE
Add set_source_df_part method on MultiDataFrameAnalyzer.

### DIFF
--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -104,6 +104,29 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
     def get_source_df_part(self, part_name):
         return self._source_dfs[part_name]
 
+    def set_source_df_part(self, part_name, df):
+        if part_name in self._source_dfs:
+            msg = f"Source df part name {part_name} already exists. Use " \
+                  f"set_source_df_col to modify existing columns"
+            logger.exception(msg)
+            return ValueError(msg)
+
+        df = copy_and_sanitize(df)
+        for col in df.columns:
+            if col in self._column_loc:
+                msg = f"Data column {col} already exists in the source_df. " \
+                      f"Use set_source_df_col to modify an existing column."
+                logger.exception(msg)
+                return ValueError(msg)
+
+        # Synchronize the list of columns:
+        self._source_dfs[part_name] = df
+        self._source_df_columns[part_name] = df.columns.tolist()
+        for col in df.columns:
+            self._column_loc[col] = df
+
+        self._source_dfs_changed = True
+
     def get_source_df_part_columns(self, part_name):
         return self._source_df_columns[part_name]
 

--- a/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
@@ -87,6 +87,17 @@ class TestAnalyzer(Analyzer, TestCase):
         with self.assertRaises(ValueError):
             self.analyzer_klass(_source_dfs={"a": self.df, "b": self.df2})
 
+    def test_set_source_df_part(self):
+        analyzer = self.analyzer_klass(_source_dfs={"a": self.df,
+                                                    "b": self.df3})
+        analyzer2 = self.analyzer_klass(_source_dfs={"a": self.df})
+        analyzer2.set_source_df_part("b", self.df3)
+        assert_frame_equal(analyzer.source_df, analyzer2.source_df)
+        self.assertEqual(analyzer._source_df_columns,
+                         analyzer2._source_df_columns)
+        self.assertEqual(analyzer._column_loc.keys(),
+                         analyzer2._column_loc.keys())
+
     def test_modify_source_df_value(self):
         analyzer = self.analyzer_klass(_source_dfs={"a": self.df,
                                                     "b": self.df3})


### PR DESCRIPTION
Adding another API function to work with the private attribute `_source_dfs`.

Will not merge until there is a clear need for this API method.