### PR TITLE
Add new base class for plots generated by PlotFactories.

### DIFF
--- a/pybleau/app/model/dataframe_plot_manager.py
+++ b/pybleau/app/model/dataframe_plot_manager.py
@@ -712,7 +712,7 @@ class DataFramePlotManager(DataElement):
         container = self.canvas_manager.get_container_for_plot(plot_desc)
         plot = self._get_overlay_plot_cont_from_desc(plot_desc)
 
-        if not hasattr(plot, "second_y_axis"):
+        if plot.second_y_axis is None:
             return
 
         plot.second_y_axis.title = new_title

--- a/pybleau/app/model/tests/test_dataframe_plot_manager.py
+++ b/pybleau/app/model/tests/test_dataframe_plot_manager.py
@@ -457,7 +457,7 @@ class TestPlotManagerUpdatePlots(BasePlotManagerTools, TestCase):
         self.model._add_new_plot(self.config4)
         desc = self.model.contained_plots[0]
         rend_styles = desc.plot_config.plot_style.renderer_styles
-        self.assertFalse(hasattr(desc.plot, "second_y_axis"))
+        self.assertIsNone(desc.plot.second_y_axis)
         renderer = desc.plot.components[1]
         self.assert_renderer_aligned(renderer, desc.plot.y_axis, dim="value")
 
@@ -466,7 +466,7 @@ class TestPlotManagerUpdatePlots(BasePlotManagerTools, TestCase):
         desc.style_edited = True
         # Recollect the descriptor since it was replaced:
         desc = self.model.contained_plots[0]
-        self.assertTrue(hasattr(desc.plot, "second_y_axis"))
+        self.assertIsNotNone(desc.plot.second_y_axis)
         self.assert_renderer_aligned(renderer, desc.plot.second_y_axis,
                                      dim="value")
 
@@ -474,13 +474,13 @@ class TestPlotManagerUpdatePlots(BasePlotManagerTools, TestCase):
         self.model._add_new_plot(self.config4)
         desc = self.model.contained_plots[0]
         rend_styles = desc.plot_config.plot_style.renderer_styles
-        self.assertFalse(hasattr(desc.plot, "second_y_axis"))
+        self.assertIsNone(desc.plot.second_y_axis)
 
         style = rend_styles[1]
         style.orientation = "right"
         desc.style_edited = True
         desc = self.model.contained_plots[0]
-        self.assertTrue(hasattr(desc.plot, "second_y_axis"))
+        self.assertIsNotNone(desc.plot.second_y_axis)
 
         style.orientation = "left"
         desc.style_edited = True
@@ -488,7 +488,7 @@ class TestPlotManagerUpdatePlots(BasePlotManagerTools, TestCase):
         renderer = desc.plot.components[1]
         self.assert_renderer_aligned(renderer, desc.plot.y_axis,
                                      dim="value")
-        self.assertFalse(hasattr(desc.plot, "second_y_axis"))
+        self.assertIsNone(desc.plot.second_y_axis)
 
     def test_change_plot_title(self):
         """ Plot title updated in the table triggers an update of actual plot.
@@ -540,7 +540,7 @@ class TestPlotManagerUpdatePlots(BasePlotManagerTools, TestCase):
         # desc recreated so re-collect it:
         desc = self.model.contained_plots[0]
         plot = desc.plot
-        self.assertTrue(hasattr(plot, "second_y_axis"))
+        self.assertIsNotNone(desc.plot.second_y_axis)
         self.assertIn(plot.second_y_axis, plot.underlays)
 
         self.assertEqual(plot.second_y_axis.title, desc.secondary_y_axis_title)

--- a/pybleau/app/plotting/multi_mapper_plot.py
+++ b/pybleau/app/plotting/multi_mapper_plot.py
@@ -1,7 +1,7 @@
 """ New Chaco plot container class to support OverlayPlotContainer objects that
 keep handles on plot elements and support secondary y-axis.
 """
-from traits.api import Bool, Int
+from traits.api import Bool, Instance, Int
 
 from chaco.api import ArrayPlotData, Legend, OverlayPlotContainer, PlotAxis, \
     PlotLabel

--- a/pybleau/app/plotting/multi_mapper_plot.py
+++ b/pybleau/app/plotting/multi_mapper_plot.py
@@ -14,8 +14,8 @@ class MultiMapperPlot(OverlayPlotContainer):
     OverlayPlotContainer that keeps a handle on axes and other plot elements.
     But it supports containing renderers with different mappers, is capable of
     aligning them, and supports multiple y-axes. Its additional attribute names
-    are often inspired from chaco's Plot class since the goal is a more flexible
-    version of that end-user level class.
+    are often inspired from chaco's Plot class since the goal is a more
+    flexible version of that end-user level class.
     """
     # -------------------------------------------------------------------------
     # Axes

--- a/pybleau/app/plotting/multi_mapper_plot.py
+++ b/pybleau/app/plotting/multi_mapper_plot.py
@@ -1,0 +1,60 @@
+""" New Chaco plot container class to support OverlayPlotContainer objects that
+keep handles on plot elements and support secondary y-axis.
+"""
+from traits.api import Bool, Int
+
+from chaco.api import ArrayPlotData, Legend, OverlayPlotContainer, PlotAxis, \
+    PlotLabel
+
+
+class MultiMapperPlot(OverlayPlotContainer):
+    """ Container to store renderers and std plot elements(axes, legend, ...).
+
+    Like the chaco DataView, this is a subclass of the chaco
+    OverlayPlotContainer that keeps a handle on axes and other plot elements.
+    But it supports containing renderers with different mappers, is capable of
+    aligning them, and supports multiple y-axes. Its additional attribute names
+    are often inspired from chaco's Plot class since the goal is a more flexible
+    version of that end-user level class.
+    """
+    # -------------------------------------------------------------------------
+    # Axes
+    # -------------------------------------------------------------------------
+
+    #: The default (bottom) horizontal axis
+    x_axis = Instance(PlotAxis)
+
+    #: The default (left) vertical axis
+    y_axis = Instance(PlotAxis)
+
+    #: The secondary vertical axis
+    second_y_axis = Instance(PlotAxis)
+
+    # -------------------------------------------------------------------------
+    # Other plot elements
+    # -------------------------------------------------------------------------
+
+    #: The data storage for the plot
+    data = Instance(ArrayPlotData)
+
+    #: The label displaying a title for the plot
+    title = Instance(PlotLabel)
+
+    #: The legend of the plot
+    legend = Instance(Legend)
+
+    # -------------------------------------------------------------------------
+    # Appearance
+    # -------------------------------------------------------------------------
+
+    #: Background color (overrides Enable Component)
+    bgcolor = "white"
+
+    #: Padding defaults.
+    padding_top = Int(50)
+    padding_bottom = Int(50)
+    padding_left = Int(50)
+    padding_right = Int(50)
+
+    #: Is the border visible?
+    border_visible = Bool(True)

--- a/pybleau/app/plotting/plot_style.py
+++ b/pybleau/app/plotting/plot_style.py
@@ -302,7 +302,7 @@ class BaseXYPlotStyle(HasStrictTraits):
         missing_mapper_msg = "The plot is missing the attribute {}. Please " \
                              "provide the mapper explicitly"
         if x_mapper is None:
-            if hasattr(plot, "x_axis"):
+            if plot.x_axis:
                 x_mapper = plot.x_axis.mapper
             else:
                 msg = missing_mapper_msg.format("x_axis")
@@ -310,7 +310,7 @@ class BaseXYPlotStyle(HasStrictTraits):
                 raise ValueError(msg)
 
         if y_mapper is None:
-            if hasattr(plot, "y_axis"):
+            if plot.y_axis:
                 y_mapper = plot.y_axis.mapper
             else:
                 msg = missing_mapper_msg.format("y_axis")
@@ -318,7 +318,7 @@ class BaseXYPlotStyle(HasStrictTraits):
                 raise ValueError(msg)
 
         if second_y_mapper is None:
-            if hasattr(plot, "second_y_axis"):
+            if hasattr(plot, "second_y_axis") and plot.second_y_axis:
                 second_y_mapper = plot.second_y_axis.mapper
 
         return x_mapper, y_mapper, second_y_mapper

--- a/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
+++ b/pybleau/app/plotting/tests/test_dataframe_plot_factories.py
@@ -1119,7 +1119,7 @@ class TestMakeHeatmapPlot(BaseTestMakePlot, TestCase):
 class BasePlotTools(object):
     def assert_no_tools(self, plot):
         self.assertEqual(plot.tools, [])
-        if hasattr(plot, "legend"):
+        if plot.legend is not None:
             self.assertFalse(plot.legend.tools, [])
             # Legend and title:
             self.assertEqual(len(plot.overlays), 2)

--- a/pybleau/app/plotting/tests/test_multi_mapper_plot.py
+++ b/pybleau/app/plotting/tests/test_multi_mapper_plot.py
@@ -1,0 +1,20 @@
+from chaco.api import OverlayPlotContainer
+from  unittest import TestCase
+
+from pybleau.app.plotting.multi_mapper_plot import MultiMapperPlot
+from pybleau.app.plotting.plot_container_style import PlotContainerStyle
+
+
+class TestMultiMapperPlot(TestCase):
+    def test_create(self):
+        plot = MultiMapperPlot()
+        self.assertIsInstance(plot, OverlayPlotContainer)
+
+    def test_create_control_padding(self):
+        plot = MultiMapperPlot(left_padding=10)
+        self.assertIsInstance(plot, OverlayPlotContainer)
+
+    def test_create_control_attr_via_container_style(self):
+        attrs = PlotContainerStyle().to_traits()
+        plot = MultiMapperPlot(**attrs)
+        self.assertIsInstance(plot, OverlayPlotContainer)

--- a/pybleau/app/plotting/tests/test_multi_mapper_plot.py
+++ b/pybleau/app/plotting/tests/test_multi_mapper_plot.py
@@ -1,5 +1,5 @@
 from chaco.api import OverlayPlotContainer
-from  unittest import TestCase
+from unittest import TestCase
 
 from pybleau.app.plotting.multi_mapper_plot import MultiMapperPlot
 from pybleau.app.plotting.plot_container_style import PlotContainerStyle


### PR DESCRIPTION
Add a new chaco plot base class similar to `Plot` from an attribute list perspective but flexible like an OverlayPlotContainer, so it supports multiple renderer mappers.