### PR TITLE
set_source_df_col triggers change event

### DIFF
--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -136,7 +136,8 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
 
         self._source_dfs_changed = True
 
-    def set_source_df_col(self, col, value, target_df_name=""):
+    def set_source_df_col(self, col, value, target_df_name="",
+                          change_notify=True):
         """ Set a DF column to a value or add a new column to one of the DFs.
 
         Note: triggers an update of the source_df, filtered_df and displayed_df
@@ -152,6 +153,10 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
 
         target_df_name : str
             Name of the dataframe to add the column to.
+
+        change_notify : bool, optional
+            Whether to trigger an event to rebuild all downstream dataframes
+            (source, filtered, displayed).
         """
         if col in self._column_loc:
             target_df = self._column_loc[col]
@@ -166,7 +171,8 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
             self._source_df_columns[target_df_name].append(col)
 
         target_df[col] = value
-        self._source_dfs_changed = True
+        if change_notify:
+            self._source_dfs_changed = True
 
     def set_source_df_val(self, index, col, value):
         """ Set a DF element to a value.

--- a/pybleau/app/model/multi_dfs_dataframe_analyzer.py
+++ b/pybleau/app/model/multi_dfs_dataframe_analyzer.py
@@ -139,6 +139,8 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
     def set_source_df_col(self, col, value, target_df_name=""):
         """ Set a DF column to a value or add a new column to one of the DFs.
 
+        Note: triggers an update of the source_df, filtered_df and displayed_df
+
         Parameters
         ----------
         col : any
@@ -151,7 +153,6 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
         target_df_name : str
             Name of the dataframe to add the column to.
         """
-        new_col_created = col not in self.column_list
         if col in self._column_loc:
             target_df = self._column_loc[col]
         else:
@@ -165,8 +166,7 @@ class MultiDataFrameAnalyzer(DataFrameAnalyzer):
             self._source_df_columns[target_df_name].append(col)
 
         target_df[col] = value
-        if new_col_created:
-            self._source_dfs_changed = True
+        self._source_dfs_changed = True
 
     def set_source_df_val(self, index, col, value):
         """ Set a DF element to a value.

--- a/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
@@ -107,6 +107,7 @@ class TestAnalyzer(Analyzer, TestCase):
         analyzer.set_source_df_col("a", "xyz")
         expected = pd.Series(["xyz"]*len(analyzer.source_df), name="a")
         assert_series_equal(analyzer.source_df["a"], expected)
+        assert_series_equal(analyzer.filtered_df["a"], expected)
 
     def test_add_source_df_col(self):
         analyzer = self.analyzer_klass(_source_dfs={"a": self.df,

--- a/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
+++ b/pybleau/app/model/tests/test_multi_df_dataframe_analyzer.py
@@ -104,10 +104,22 @@ class TestAnalyzer(Analyzer, TestCase):
     def test_modify_existing_source_df_col(self):
         analyzer = self.analyzer_klass(_source_dfs={"a": self.df,
                                                     "b": self.df3})
+        # With notification
         analyzer.set_source_df_col("a", "xyz")
-        expected = pd.Series(["xyz"]*len(analyzer.source_df), name="a")
-        assert_series_equal(analyzer.source_df["a"], expected)
-        assert_series_equal(analyzer.filtered_df["a"], expected)
+        expected1 = pd.Series(["xyz"]*len(analyzer.source_df), name="a")
+        assert_series_equal(analyzer.source_df["a"], expected1)
+        assert_series_equal(analyzer.filtered_df["a"], expected1)
+        assert_series_equal(analyzer.displayed_df["a"], expected1)
+
+        # Without notification:
+        analyzer.set_source_df_col("a", "abc", change_notify=False)
+        expected2 = pd.Series(["abc"] * len(analyzer.source_df), name="a")
+        assert_series_equal(analyzer.source_df["a"], expected2)
+        assert_series_equal(analyzer.filtered_df["a"], expected1)
+        assert_series_equal(analyzer.displayed_df["a"], expected1)
+        analyzer._source_dfs_changed = True
+        assert_series_equal(analyzer.filtered_df["a"], expected2)
+        assert_series_equal(analyzer.displayed_df["a"], expected2)
 
     def test_add_source_df_col(self):
         analyzer = self.analyzer_klass(_source_dfs={"a": self.df,


### PR DESCRIPTION
Fix set_source_df_col: always trigger the _source_dfs_changed event on set_source_df_col. Otherwise, changing a column won't trigger an update of the source and `filtered_df`.

Fixes https://github.com/KBIbiopharma/pybleau/issues/189